### PR TITLE
Support smarter logging / Request timeouts

### DIFF
--- a/functional_tests/cluster_setup.py
+++ b/functional_tests/cluster_setup.py
@@ -1,11 +1,25 @@
 import pytest
 
 from lib.cluster import Cluster
-
+from provision.fetch_sg_logs import fetch_sync_gateway_logs
 
 @pytest.fixture()
-def cluster():
+def cluster(request):
+
+    def fetch_logs():
+
+        # Fetch logs if a test fails
+        if request.node.rep_call.failed:
+            # example nodeid: tests/test_single_user_multiple_channels.py::test_1
+            remove_slash = request.node.nodeid.replace("/", "-")
+            test_id_elements = remove_slash.split("::")
+            log_zip_prefix = "{0}-{1}".format(test_id_elements[0], test_id_elements[1])
+            fetch_sync_gateway_logs(log_zip_prefix)
+
+    request.addfinalizer(fetch_logs)
+
     c = Cluster("conf/hosts.ini")
+
     return c
 
 

--- a/functional_tests/conftest.py
+++ b/functional_tests/conftest.py
@@ -1,0 +1,12 @@
+import pytest
+
+# http://pytest.org/dev/example/simple.html#making-test-result-information-available-in-fixtures
+@pytest.mark.tryfirst
+def pytest_runtest_makereport(item, call, __multicall__):
+    # execute all other hooks to obtain the report object
+    rep = __multicall__.execute()
+
+    # set an report attribute for each phase of a call, which can
+    # be "setup", "call", "teardown"
+    setattr(item, "rep_" + rep.when, rep)
+    return rep

--- a/provision/ansible/playbooks/fetch-sync-gateway-logs.yml
+++ b/provision/ansible/playbooks/fetch-sync-gateway-logs.yml
@@ -5,5 +5,5 @@
 
   - name: Fetch sync_gateway logs
     # Do not validate checksum as this is just a passive grab of the logs. Since they are continuously being appended to, the checksum may fail
-    fetch: src=/home/sync_gateway/logs/sync_gateway_access.log dest=/tmp/sg_logs/{{ hostvars[inventory_hostname]['ansible_eth0']['ipv4']['address'] }}/ fail_on_missing=yes flat=yes validate_checksum=no
-    fetch: src=/home/sync_gateway/logs/sync_gateway_error.log dest=/tmp/sg_logs/{{ hostvars[inventory_hostname]['ansible_eth0']['ipv4']['address'] }}/ fail_on_missing=yes flat=yes validate_checksum=no
+    fetch: src=/home/sync_gateway/logs/sync_gateway_access.log dest=/tmp/sg_logs/{{ hostvars[inventory_hostname]['ansible_eth0']['ipv4']['address'] }}/ fail_on_missing=no flat=yes validate_checksum=no
+    fetch: src=/home/sync_gateway/logs/sync_gateway_error.log dest=/tmp/sg_logs/{{ hostvars[inventory_hostname]['ansible_eth0']['ipv4']['address'] }}/ fail_on_missing=no flat=yes validate_checksum=no

--- a/provision/ansible/playbooks/install-sync-gateway-source.yml
+++ b/provision/ansible/playbooks/install-sync-gateway-source.yml
@@ -40,6 +40,7 @@
     branch:
 
   tasks:
+  # Clone and build sync_gateway
   - name: clone sync gateway git repo
     git: repo=https://github.com/couchbase/sync_gateway.git
          dest=/home/centos/sync_gateway
@@ -50,6 +51,16 @@
     shell: git submodule init && git submodule update chdir=/home/centos/sync_gateway
   - name: build sync gateway
     shell: ./build.sh chdir=/home/centos/sync_gateway
+
+  # Add sync_gateway user and copy binary from centos user
+  - name: add sync gateway user
+    user: name=sync_gateway createhome=yes
+  - name: make service install script executable
+    file: path=/home/centos/sync_gateway/service/sync_gateway_service_install.sh mode=a+x
+  - name: copy sync gateway binary to sync_gateway home
+    shell: cp /home/centos/sync_gateway/bin/sync_gateway /home/sync_gateway
+  - name: change permissions of sync gateway executable
+    file: path=/home/sync_gateway/sync_gateway mode=a+x
 
 # Install and start service
 - hosts: sync_gateways

--- a/provision/ansible/playbooks/tasks/start-sync-gateway.yml
+++ b/provision/ansible/playbooks/tasks/start-sync-gateway.yml
@@ -1,13 +1,5 @@
-# Add sync_gateway user, copy new config
-- name: add sync gateway user
-  user: name=sync_gateway createhome=yes
-- name: make service install script executable
-  file: path=/home/centos/sync_gateway/service/sync_gateway_service_install.sh mode=a+x
-- name: copy sync gateway binary to sync_gateway home
-  shell: cp /home/centos/sync_gateway/bin/sync_gateway /home/sync_gateway
-- name: change permissions of sync gateway executable
-  file: path=/home/sync_gateway/sync_gateway mode=a+x
-- debug: msg="Starting sync_gateway with config {{ sync_gateway_config_filepath }}"
+# Copy new config and start
+- debug: msg="Copying config {{ sync_gateway_config_filepath }}"
 - name: copy sync gateway config to host
   template: src={{ sync_gateway_config_filepath }} dest=/home/sync_gateway/sync_gateway.json owner=sync_gateway group=sync_gateway mode=0644 force=true
 

--- a/provision/ansible/playbooks/tasks/stop-sync-gateway.yml
+++ b/provision/ansible/playbooks/tasks/stop-sync-gateway.yml
@@ -8,3 +8,9 @@
 - name: verify sync_gateway not listening on port
   wait_for: port=4985 delay=1 state=stopped
 
+# Delete logs and .pindex files
+- name: delete sync_gateway logs
+  shell: rm -f /home/sync_gateway/logs/*.log
+- name: delete sync_gateway pindex files
+  shell: rm -rf /home/sync_gateway/*.pindex
+

--- a/provision/fetch_sg_logs.py
+++ b/provision/fetch_sg_logs.py
@@ -5,22 +5,22 @@ import time
 from ansible_runner import run_ansible_playbook
 
 
-def fetch_sync_gateway_logs():
+def fetch_sync_gateway_logs(prefix):
 
+    print("\n\n>>> Pulling logs")
     # fetch logs from sync_gateway instances
     run_ansible_playbook("fetch-sync-gateway-logs.yml")
 
-    # zip logs, rename, and copy to desktop
+    # zip logs and timestamp
     if os.path.isdir("/tmp/sg_logs"):
+
         date_time = time.strftime("%Y-%m-%d-%H-%M-%S")
-        name = "/tmp/{}-sglogs".format(date_time)
+        name = "/tmp/{}-{}-sglogs".format(prefix, date_time)
 
         shutil.make_archive(name, "zip", "/tmp/sg_logs")
-        home = os.environ["HOME"]
 
-        shutil.copy("{}.zip".format(name), "{}/Desktop".format(home))
         shutil.rmtree("/tmp/sg_logs")
-        print(">>> Copied {}.zip to {}/Desktop".format(name, home))
+        print(">>> sync_gateway logs copied here {}\n".format(name))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- If a test fails, the framework will snapshot the logs from sync_gateways from that test to /tmp
- Add 30 sec timeout on user requests