### PR TITLE
Add test for launching with invalid num_shards

### DIFF
--- a/conf/sync_gateway_functional_tests_32_shard.json
+++ b/conf/sync_gateway_functional_tests_32_shard.json
@@ -1,0 +1,40 @@
+{
+    "interface":":4984",
+    "adminInterface": "0.0.0.0:4985",
+    "maxIncomingConnections": 0,
+    "maxCouchbaseConnections": 16,
+    "maxFileDescriptors": 90000,
+    "slowServerCallWarningThreshold": 500,
+    "compressResponses": true,
+    "log":["*"],
+    "verbose":"true",
+    "cluster_config": {
+        "server":"http://{{ couchbase_server_primary_node }}:8091",
+        "data_dir":".",
+        "bucket":"data-bucket"
+    },
+    "databases":{
+        "db":{
+            "feed_type":"DCPSHARD",
+            "feed_params":{
+                "num_shards":32
+            },
+            "server":"http://{{ couchbase_server_primary_node }}:8091",
+            "bucket":"data-bucket",
+            "users":{
+                "GUEST":{
+                    "disabled":true,
+                    "admin_channels":[
+                        "*"
+                    ]
+                }
+            },
+            "channel_index":{
+                "server":"http://{{ couchbase_server_primary_node }}:8091",
+                "bucket":"index-bucket",
+                "writer":{{ is_index_writer }}
+            }
+        }
+    }
+}
+

--- a/functional_tests/test_different_shard_values.py
+++ b/functional_tests/test_different_shard_values.py
@@ -1,0 +1,19 @@
+import time
+
+import pytest
+import concurrent.futures
+
+from lib.admin import Admin
+
+from fixtures import cluster
+
+@pytest.mark.extendedsanity
+def test_dcp_reshard(cluster):
+
+    cluster.reset("sync_gateway_default_functional_tests.json")
+
+    # Reset with the same config, except the num_shards has changed
+    restart_status = cluster.sync_gateways[0].restart("sync_gateway_functional_tests_32_shard.json")
+
+    # Assert that the sync_gateway fails to launch
+    assert restart_status != 0

--- a/lib/syncgateway.py
+++ b/lib/syncgateway.py
@@ -16,32 +16,38 @@ class SyncGateway:
         return r.text
 
     def stop(self):
-        run_targeted_ansible_playbook(
+        status = run_targeted_ansible_playbook(
             "stop-sync-gateway.yml",
-            target_name=self.hostname
+            target_name=self.hostname,
+            stop_on_fail=False,
         )
+        return status
 
     def start(self, config):
         conf_path = os.path.abspath("conf/" + config)
 
         print(">>> Starting sync_gateway with configuration: {}".format(conf_path))
 
-        run_targeted_ansible_playbook(
+        status = run_targeted_ansible_playbook(
             "start-sync-gateway.yml",
             extra_vars="sync_gateway_config_filepath={0}".format(conf_path),
-            target_name=self.hostname
+            target_name=self.hostname,
+            stop_on_fail=False
         )
+        return status
 
     def restart(self, config):
         conf_path = os.path.abspath("conf/" + config)
 
         print(">>> Restarting sync_gateway with configuration: {}".format(conf_path))
 
-        run_targeted_ansible_playbook(
+        status = run_targeted_ansible_playbook(
             "reset-sync-gateway.yml",
             extra_vars="sync_gateway_config_filepath={0}".format(conf_path),
-            target_name=self.hostname
+            target_name=self.hostname,
+            stop_on_fail=False
         )
+        return status
 
     def __repr__(self):
         return "SyncGateway: {}:{}\n".format(self.hostname, self.ip)

--- a/provision/ansible/playbooks/reset-sync-gateway.yml
+++ b/provision/ansible/playbooks/reset-sync-gateway.yml
@@ -7,6 +7,12 @@
   tasks:
   - include: tasks/stop-sync-gateway.yml
 
+  # Delete logs and .pindex files
+  - name: delete sync_gateway logs
+    shell: rm -f /home/sync_gateway/logs/*.log
+  - name: delete sync_gateway pindex files
+    shell: rm -rf /home/sync_gateway/*.pindex
+
 # Deploy sync gateway configs
 - hosts: sync_gateways
   sudo: true

--- a/provision/ansible_runner.py
+++ b/provision/ansible_runner.py
@@ -24,7 +24,7 @@ def run_ansible_playbook(script_name, extra_vars=None):
 
     os.chdir("../../../")
 
-def run_targeted_ansible_playbook(script_name, target_name, extra_vars=None):
+def run_targeted_ansible_playbook(script_name, target_name, extra_vars=None, stop_on_fail=True):
 
     # Need to cd here to pick up dynamic inventory
     os.chdir("provision/ansible/playbooks")
@@ -38,9 +38,11 @@ def run_targeted_ansible_playbook(script_name, target_name, extra_vars=None):
     else:
         status = subprocess.call(["ansible-playbook", "-i", "../../../provisioning_config", script_name, "--limit", target_name])
 
-    if status != 0:
+    if status != 0 and stop_on_fail:
         sys.exit(1)
 
     os.chdir("../../../")
+
+    return status
 
 


### PR DESCRIPTION
- Test for relaunching with inconsistent number of shards
- Optionally return status for targeted ansible playbook execution so that we can assert on exit status of ansible actions in our test scripts