### PR TITLE
Fix lib.admin users

### DIFF
--- a/functional_tests/test_dcp_reshard.py
+++ b/functional_tests/test_dcp_reshard.py
@@ -15,12 +15,9 @@ def test_dcp_reshard(cluster):
     start = time.time()
 
     admin = Admin(cluster.sync_gateways[2])
-    admin.register_user(target=cluster.sync_gateways[3], db="db", name="traun", password="password", channels=["ABC", "NBC", "CBS"])
-    admin.register_user(target=cluster.sync_gateways[2], db="db", name="seth", password="password", channels=["FOX"])
-    users = admin.get_users()
 
-    traun = users["traun"]
-    seth = users["seth"]
+    traun = admin.register_user(target=cluster.sync_gateways[3], db="db", name="traun", password="password", channels=["ABC", "NBC", "CBS"])
+    seth = admin.register_user(target=cluster.sync_gateways[2], db="db", name="seth", password="password", channels=["FOX"])
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
 

--- a/functional_tests/test_multiple_db_single_data_bucket_single_index_bucket.py
+++ b/functional_tests/test_multiple_db_single_data_bucket_single_index_bucket.py
@@ -16,23 +16,24 @@ def test_multiple_db_single_data_bucket_single_index_bucket(cluster):
 
     admin = Admin(cluster.sync_gateways[0])
 
-    admin.register_bulk_users(target=cluster.sync_gateways[0], db="db", name_prefix="bulk_db_user", number=num_db_users, password="password", channels=["ABC"])
-    admin.register_bulk_users(target=cluster.sync_gateways[0], db="db2", name_prefix="bulk_db2_user", number=num_db2_users, password="password", channels=["ABC"])
+    db_one_users = admin.register_bulk_users(target=cluster.sync_gateways[0], db="db", name_prefix="bulk_db_user", number=num_db_users, password="password", channels=["ABC"])
+    db_two_users = admin.register_bulk_users(target=cluster.sync_gateways[0], db="db2", name_prefix="bulk_db2_user", number=num_db2_users, password="password", channels=["ABC"])
 
-    users = admin.get_users().values()
-
-    assert len(users) == 10
+    all_users = list(db_one_users)
+    all_users.extend(db_two_users)
+    assert len(all_users) == 10
 
     # Round robin
     num_sgs = len(cluster.sync_gateways)
     count = 1
-    for user in users:
+
+    for user in all_users:
         user.add_docs(num_docs_per_user, uuid_names=True, bulk=True)
         user.target = cluster.sync_gateways[(count + 1) % num_sgs]
         count += 1
 
-    all_cache_ids = [key for user in users for key in user.cache.keys()]
+    all_cache_ids = [key for user in all_users for key in user.cache.keys()]
 
-    for user in users:
+    for user in all_users:
         user.verify_ids_from_changes(1000, all_cache_ids)
 

--- a/functional_tests/test_multiple_db_unique_data_bucket_unique_index_bucket.py
+++ b/functional_tests/test_multiple_db_unique_data_bucket_unique_index_bucket.py
@@ -14,36 +14,29 @@ def test_multiple_db_unique_data_bucket_unique_index_bucket(cluster):
 
     admin = Admin(cluster.sync_gateways[0])
 
-    admin.register_bulk_users(target=cluster.sync_gateways[0], db="db", name_prefix="bulk_db_user", number=num_db_users, password="password", channels=["ABC"])
-    admin.register_bulk_users(target=cluster.sync_gateways[0], db="db2", name_prefix="bulk_db2_user", number=num_db2_users, password="password", channels=["ABC"])
+    db_one_users = admin.register_bulk_users(target=cluster.sync_gateways[0], db="db", name_prefix="bulk_db_user", number=num_db_users, password="password", channels=["ABC"])
+    db_two_users = admin.register_bulk_users(target=cluster.sync_gateways[0], db="db2", name_prefix="bulk_db2_user", number=num_db2_users, password="password", channels=["ABC"])
 
-    users = admin.get_users()
-
-    assert len(users) == 10
+    all_users = list(db_one_users)
+    all_users.extend(db_two_users)
+    assert len(all_users) == 10
 
     # Round robin
     num_sgs = len(cluster.sync_gateways)
     count = 1
-    for user in users.values():
+    for user in all_users:
         user.add_docs(num_docs_per_user, uuid_names=True, bulk=True)
         user.target = cluster.sync_gateways[(count + 1) % num_sgs]
         count += 1
 
     # Build expected ids
-    db_ids = []
-    db2_ids = []
-    for user in users:
-        if user.startswith("bulk_db_"):
-            u = users[user]
-            db_ids.extend(u.cache.keys())
-        if user.startswith("bulk_db2_"):
-            u = users[user]
-            db2_ids.extend(u.cache.keys())
+    db_one_ids = [key for user in db_one_users for key in user.cache.keys()]
+    db_two_ids = [key for user in db_two_users for key in user.cache.keys()]
 
-    for user in users:
-        if user.startswith("bulk_db_"):
-            u = users[user]
-            u.verify_ids_from_changes(500, db_ids)
-        if user.startswith("bulk_db2_"):
-            u = users[user]
-            u.verify_ids_from_changes(500, db2_ids)
+    # Verify docs for db_one_users
+    for user in db_one_users:
+        user.verify_ids_from_changes(500, db_one_ids)
+
+    # Verify docs for db_two_users
+    for user in db_two_users:
+        user.verify_ids_from_changes(500, db_two_ids)

--- a/functional_tests/test_multiple_users_multiple_channels.py
+++ b/functional_tests/test_multiple_users_multiple_channels.py
@@ -17,15 +17,9 @@ def test_1(cluster):
 
     admin = Admin(sgs[0])
 
-    admin.register_user(target=sgs[0], db="db", name="seth", password="password", channels=["ABC"])
-    admin.register_user(target=sgs[0], db="db", name="adam", password="password", channels=["NBC", "CBS"])
-    admin.register_user(target=sgs[0], db="db", name="traun", password="password", channels=["ABC", "NBC", "CBS"])
-
-    users = admin.get_users()
-
-    seth = users["seth"]
-    adam = users["adam"]
-    traun = users["traun"]
+    seth = admin.register_user(target=sgs[0], db="db", name="seth", password="password", channels=["ABC"])
+    adam = admin.register_user(target=sgs[0], db="db", name="adam", password="password", channels=["NBC", "CBS"])
+    traun = admin.register_user(target=sgs[0], db="db", name="traun", password="password", channels=["ABC", "NBC", "CBS"])
 
     # TODO use bulk docs
     seth.add_docs(2356, uuid_names=True)  # ABC

--- a/functional_tests/test_multiple_users_single_channel.py
+++ b/functional_tests/test_multiple_users_single_channel.py
@@ -17,15 +17,9 @@ def test_1(cluster):
 
     admin = Admin(sgs[0])
 
-    admin.register_user(target=sgs[0], db="db", name="seth", password="password", channels=["ABC"])
-    admin.register_user(target=sgs[0], db="db", name="adam", password="password", channels=["ABC"])
-    admin.register_user(target=sgs[0], db="db", name="traun", password="password", channels=["ABC"])
-
-    users = admin.get_users()
-
-    seth = users["seth"]
-    adam = users["adam"]
-    traun = users["traun"]
+    seth = admin.register_user(target=sgs[0], db="db", name="seth", password="password", channels=["ABC"])
+    adam = admin.register_user(target=sgs[0], db="db", name="adam", password="password", channels=["ABC"])
+    traun = admin.register_user(target=sgs[0], db="db", name="traun", password="password", channels=["ABC"])
 
     seth.add_docs(1000, uuid_names=True)  # ABC
     adam.add_docs(3000, uuid_names=True, bulk=True)  # ABC

--- a/functional_tests/test_single_user_multiple_channels.py
+++ b/functional_tests/test_single_user_multiple_channels.py
@@ -13,13 +13,7 @@ def test_1(cluster):
     sgs = cluster.sync_gateways
 
     admin = Admin(sgs[0])
-    admin.register_user(target=sgs[0], db="db", name="seth", password="password", channels=["ABC", "CBS", "NBC", "FOX"])
-    admin.register_user(target=sgs[0], db="db", name="admin", password="password", channels=["*"])
-
-    users = admin.get_users()
-
-    seth = users["seth"]
-    admin = users["admin"]
+    seth = admin.register_user(target=sgs[0], db="db", name="seth", password="password", channels=["ABC", "CBS", "NBC", "FOX"])
 
     # Round robin
     count = 1

--- a/functional_tests/test_single_user_single_channel.py
+++ b/functional_tests/test_single_user_single_channel.py
@@ -13,22 +13,17 @@ def test_1(cluster):
     sgs = cluster.sync_gateways
 
     admin = Admin(sgs[0])
-    admin.register_user(target=sgs[0], db="db", name="seth", password="password", channels=["ABC"])
-    admin.register_user(target=sgs[0], db="db", name="admin", password="password", channels=["*"])
-
-    users = admin.get_users()
-
-    seth = users["seth"]
-    admin = users["admin"]
+    seth = admin.register_user(target=sgs[0], db="db", name="seth", password="password", channels=["ABC"])
+    admin_user = admin.register_user(target=sgs[0], db="db", name="admin", password="password", channels=["*"])
 
     seth.add_docs(7000, uuid_names=True)
-    admin.add_docs(3000, uuid_names=True)
+    admin_user.add_docs(3000, uuid_names=True)
 
     assert len(seth.cache) == 7000
-    assert len(admin.cache) == 3000
+    assert len(admin_user.cache) == 3000
 
     print(seth)
-    print(admin)
+    print(admin_user)
 
     time.sleep(10)
 
@@ -36,10 +31,10 @@ def test_1(cluster):
     seth.verify_ids_from_changes(7000, seth_cache_ids)
 
     # Admin should have doc ids from seth + admin
-    admin_cache_ids = admin.cache.keys()
+    admin_cache_ids = admin_user.cache.keys()
     admin_cache_ids.extend(seth_cache_ids)
 
-    admin.verify_ids_from_changes(10000, admin_cache_ids)
+    admin_user.verify_ids_from_changes(10000, admin_cache_ids)
 
     end = time.time()
     print("TIME:{}s".format(end - start))

--- a/functional_tests/test_single_user_single_channel_doc_updates.py
+++ b/functional_tests/test_single_user_single_channel_doc_updates.py
@@ -24,12 +24,7 @@ def test_update_docs_multiple_users_multiple_channels(cluster):
 
     admin = Admin(sgs[0])
 
-    admin.register_user(target=sgs[0], db="db", name=username, password=password, channels=channels)
-
-    users = admin.get_users()
-
-    single_user = users[username]
-    assert len(users) == 1
+    single_user = admin.register_user(target=sgs[0], db="db", name=username, password=password, channels=channels)
 
     # Not using bulk docs
     single_user.add_docs(num_docs)

--- a/lib/admin.py
+++ b/lib/admin.py
@@ -6,15 +6,6 @@ from lib.user import User
 from lib.scenarioprinter import ScenarioPrinter
 from lib import settings
 
-# Admin
-# GET /
-# GET /_all_dbs
-# PUT /db/
-# DELETE /db/
-# POST /DB/_compact
-# POST /DB/_resync
-
-
 
 class Admin:
 
@@ -42,7 +33,7 @@ class Admin:
             raise("Channels needs to be a list")
 
         users = []
-        with concurrent.futures.ThreadPoolExecutor(max_workers=100) as executor:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=settings.MAX_REQUEST_WORKERS) as executor:
             futures = [executor.submit(self.register_user, target=target, db=db, name="{}_{}".format(name_prefix, i), password=password, channels=channels) for i in range(number)]
             for future in concurrent.futures.as_completed(futures):
                 try:

--- a/lib/admin.py
+++ b/lib/admin.py
@@ -15,6 +15,7 @@ from lib import settings
 # POST /DB/_resync
 
 
+
 class Admin:
 
     def __init__(self, sync_gateway):
@@ -30,24 +31,27 @@ class Admin:
 
         r = requests.put("{0}/{1}/_user/{2}".format(self.admin_url, db, name), headers=headers, timeout=settings.HTTP_REQ_TIMEOUT, data=json.dumps(data))
         r.raise_for_status()
+
         self._printer.print_user_add()
 
-        self.users[name] = User(target, db, name, password, channels)
+        return User(target, db, name, password, channels)
 
     def register_bulk_users(self, target, db, name_prefix, number, password, channels):
 
         if type(channels) is not list:
             raise("Channels needs to be a list")
 
+        users = []
         with concurrent.futures.ThreadPoolExecutor(max_workers=100) as executor:
             futures = [executor.submit(self.register_user, target=target, db=db, name="{}_{}".format(name_prefix, i), password=password, channels=channels) for i in range(number)]
             for future in concurrent.futures.as_completed(futures):
                 try:
-                    result = future.result()
+                    user = future.result()
+                    users.append(user)
                 except Exception as e:
-                    print("Error adding user: {}".format(e))
+                    raise("register_bulk_users failed: {}".format(e))
 
-    def get_users(self):
-        return self.users
+        if len(users) != number:
+            raise("Not all users added during register_bulk users")
 
-
+        return users

--- a/lib/scenarioprinter.py
+++ b/lib/scenarioprinter.py
@@ -40,6 +40,3 @@ class ScenarioPrinter:
 
         self._changes_line += " {}:{} ".format(user, number)
         self._changes_count += 1
-
-
-

--- a/lib/settings.py
+++ b/lib/settings.py
@@ -1,3 +1,6 @@
 
 # the timeout for HTTP Requests, in seconds
-HTTP_REQ_TIMEOUT=30  
+HTTP_REQ_TIMEOUT = 30
+
+# Number of thread workers for requests
+MAX_REQUEST_WORKERS = 100

--- a/lib/user.py
+++ b/lib/user.py
@@ -1,10 +1,6 @@
 import requests
 import concurrent.futures
 import json
-import pprint
-import copy_reg
-import types
-import time
 import base64
 import uuid
 import re
@@ -80,7 +76,7 @@ class User:
             doc_names = ["test-" + str(i) for i in range(num_docs)]
 
         if not bulk:
-            with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=settings.MAX_REQUEST_WORKERS) as executor:
                 future_to_docs = {executor.submit(self.add_doc, doc): doc for doc in doc_names}
                 for future in concurrent.futures.as_completed(future_to_docs):
                     doc = future_to_docs[future]
@@ -89,7 +85,7 @@ class User:
                     except Exception as exc:
                         print('Generated an exception while adding doc_id : %s %s' % (doc, exc))
         else:
-            with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=settings.MAX_REQUEST_WORKERS) as executor:
                 future = [executor.submit(self.add_bulk_docs, doc_names)]
                 for f in concurrent.futures.as_completed(future):
                     try:
@@ -124,7 +120,7 @@ class User:
             resp.raise_for_status()
                 
     def update_docs(self, num_revs_per_doc=1):
-        with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=settings.MAX_REQUEST_WORKERS) as executor:
             future_to_docs = {executor.submit(self.update_doc, doc_id, num_revs_per_doc): doc_id for doc_id in self.cache.keys()}
             
             for future in concurrent.futures.as_completed(future_to_docs):


### PR DESCRIPTION
- admin.register_user now returns a User object
- admin.register_bulk_users now returns a list of User objects
- added settings.MAX_REQUEST_WORKERS = 100 to tune concurrent requests across library
