### PR TITLE
Sync sanity scenarios

### DIFF
--- a/conf/sync_gateway_custom_sync_access_sanity.json
+++ b/conf/sync_gateway_custom_sync_access_sanity.json
@@ -1,0 +1,47 @@
+{
+    "interface":":4984",
+    "adminInterface": "0.0.0.0:4985",
+    "maxIncomingConnections": 0,
+    "maxCouchbaseConnections": 16,
+    "maxFileDescriptors": 90000,
+    "slowServerCallWarningThreshold": 500,
+    "compressResponses": true,
+    "log":["*"],
+    "verbose":"true",
+    "cluster_config": {
+        "server":"http://{{ couchbase_server_primary_node }}:8091",
+        "data_dir":".",
+        "bucket":"cbgt-bucket"
+    },
+    "databases":{
+        "db":{
+            "feed_type":"DCPSHARD",
+            "feed_params":{
+                "num_shards":64
+            },
+            "server":"http://{{ couchbase_server_primary_node }}:8091",
+            "bucket":"data-bucket",
+            "users":{
+                "GUEST":{
+                    "disabled":true,
+                    "admin_channels":[
+                        "*"
+                    ]
+                }
+            },
+            "channel_index":{
+                "server":"http://{{ couchbase_server_primary_node }}:8091",
+                "bucket":"index-bucket",
+                "writer":{{ is_index_writer }}
+            },
+            "sync":
+            `function(doc, oldDoc){
+                if (doc.content && doc.content.grant_access == "true") {
+                    access("seth", "ABC")
+                }
+                channel(doc.channels);
+            }`
+        }
+    }
+}
+

--- a/conf/sync_gateway_custom_sync_channel_sanity.json
+++ b/conf/sync_gateway_custom_sync_channel_sanity.json
@@ -1,0 +1,53 @@
+{
+    "interface":":4984",
+    "adminInterface": "0.0.0.0:4985",
+    "maxIncomingConnections": 0,
+    "maxCouchbaseConnections": 16,
+    "maxFileDescriptors": 90000,
+    "slowServerCallWarningThreshold": 500,
+    "compressResponses": true,
+    "log":["*"],
+    "verbose":"true",
+    "cluster_config": {
+        "server":"http://{{ couchbase_server_primary_node }}:8091",
+        "data_dir":".",
+        "bucket":"cbgt-bucket"
+    },
+    "databases":{
+        "db":{
+            "feed_type":"DCPSHARD",
+            "feed_params":{
+                "num_shards":64
+            },
+            "server":"http://{{ couchbase_server_primary_node }}:8091",
+            "bucket":"data-bucket",
+            "users":{
+                "GUEST":{
+                    "disabled":true,
+                    "admin_channels":[
+                        "*"
+                    ]
+                }
+            },
+            "channel_index":{
+                "server":"http://{{ couchbase_server_primary_node }}:8091",
+                "bucket":"index-bucket",
+                "writer":{{ is_index_writer }}
+            },
+            "sync":
+            `function(doc, oldDoc){
+
+                if (oldDoc == null && doc.channels) {
+                    // When docs are created, send them to one channel
+                    channel("tv_station_channel");
+                } else if (oldDoc != null && doc.channels) {
+                    // When docs are updated, send them to their original channel
+                    channel(doc.channels);
+                } else {
+                    throw({forbidden: "No channel!"});
+                }
+            }`
+        }
+    }
+}
+

--- a/conf/sync_gateway_custom_sync_require_roles.json
+++ b/conf/sync_gateway_custom_sync_require_roles.json
@@ -1,0 +1,52 @@
+{
+    "interface":":4984",
+    "adminInterface": "0.0.0.0:4985",
+    "maxIncomingConnections": 0,
+    "maxCouchbaseConnections": 16,
+    "maxFileDescriptors": 90000,
+    "slowServerCallWarningThreshold": 500,
+    "compressResponses": true,
+    "log":["*"],
+    "verbose":"true",
+    "cluster_config": {
+        "server":"http://{{ couchbase_server_primary_node }}:8091",
+        "data_dir":".",
+        "bucket":"cbgt-bucket"
+    },
+    "databases":{
+        "db":{
+            "feed_type":"DCPSHARD",
+            "feed_params":{
+                "num_shards":64
+            },
+            "server":"http://{{ couchbase_server_primary_node }}:8091",
+            "bucket":"data-bucket",
+            "users":{
+                "GUEST":{
+                    "disabled":true,
+                    "admin_channels":[
+                        "*"
+                    ]
+                }
+            },
+            "channel_index":{
+                "server":"http://{{ couchbase_server_primary_node }}:8091",
+                "bucket":"index-bucket",
+                "writer":{{ is_index_writer }}
+            },
+            "sync":
+            `function(doc, oldDoc){
+                if (doc.channel.indexOf("KMOW") > -1 || doc.channel.indexOf("HWOD") > -1 || doc.channel.indexOf("KDWB") > -1) {
+                    requireRole("radio_stations")
+                    channel(doc.channels);
+                } else if (doc.channel.indexOf("ABC") > -1 || doc.channel.indexOf("CBS") > -1 || doc.channel.indexOf("NBC") > -1) {
+                    requireRole("tv_stations")
+                    channel(doc.channels);
+                } else {
+                    throw({forbidden: "You have to have access to radio_stations or tv_stations!"})
+                }
+            }`
+        }
+    }
+}
+

--- a/conf/sync_gateway_custom_sync_require_roles.json
+++ b/conf/sync_gateway_custom_sync_require_roles.json
@@ -36,15 +36,14 @@
             },
             "sync":
             `function(doc, oldDoc){
-                if (doc.channel.indexOf("KMOW") > -1 || doc.channel.indexOf("HWOD") > -1 || doc.channel.indexOf("KDWB") > -1) {
-                    requireRole("radio_stations")
-                    channel(doc.channels);
-                } else if (doc.channel.indexOf("ABC") > -1 || doc.channel.indexOf("CBS") > -1 || doc.channel.indexOf("NBC") > -1) {
-                    requireRole("tv_stations")
-                    channel(doc.channels);
+                if (doc.channels.indexOf("KMOW") > -1 || doc.channels.indexOf("HWOD") > -1 || doc.channels.indexOf("KDWB") > -1) {
+                    requireRole("radio_stations");
+                } else if (doc.channels.indexOf("ABC") > -1 || doc.channels.indexOf("CBS") > -1 || doc.channels.indexOf("NBC") > -1) {
+                    requireRole("tv_stations");
                 } else {
                     throw({forbidden: "You have to have access to radio_stations or tv_stations!"})
                 }
+                channel(doc.channels);
             }`
         }
     }

--- a/conf/sync_gateway_custom_sync_role_sanity.json
+++ b/conf/sync_gateway_custom_sync_role_sanity.json
@@ -1,0 +1,47 @@
+{
+    "interface":":4984",
+    "adminInterface": "0.0.0.0:4985",
+    "maxIncomingConnections": 0,
+    "maxCouchbaseConnections": 16,
+    "maxFileDescriptors": 90000,
+    "slowServerCallWarningThreshold": 500,
+    "compressResponses": true,
+    "log":["*"],
+    "verbose":"true",
+    "cluster_config": {
+        "server":"http://{{ couchbase_server_primary_node }}:8091",
+        "data_dir":".",
+        "bucket":"cbgt-bucket"
+    },
+    "databases":{
+        "db":{
+            "feed_type":"DCPSHARD",
+            "feed_params":{
+                "num_shards":64
+            },
+            "server":"http://{{ couchbase_server_primary_node }}:8091",
+            "bucket":"data-bucket",
+            "users":{
+                "GUEST":{
+                    "disabled":true,
+                    "admin_channels":[
+                        "*"
+                    ]
+                }
+            },
+            "channel_index":{
+                "server":"http://{{ couchbase_server_primary_node }}:8091",
+                "bucket":"index-bucket",
+                "writer":{{ is_index_writer }}
+            },
+            "sync":
+            `function(doc, oldDoc){
+                if (doc.content && doc.content.grant_access == "true") {
+                    role("seth", "role:tv_stations");
+                }
+                channel(doc.channels);
+            }`
+        }
+    }
+}
+

--- a/functional_tests/test_sync.py
+++ b/functional_tests/test_sync.py
@@ -92,6 +92,8 @@ def test_sync_channel_sanity(cluster):
     # Verify that all docs have been flaged with _removed = true in changes feed for subscriber
     verify_docs_removed(subscriber, expected_num_docs=len(all_docs.items()), expected_docs=all_docs)
 
+    # TODO Push more docs to channel and make sure they do not show up in the users changes feed.
+
 
 @pytest.mark.sanity
 def test_sync_role_sanity(cluster):

--- a/functional_tests/test_sync.py
+++ b/functional_tests/test_sync.py
@@ -48,7 +48,7 @@ def test_sync_access_sanity(cluster):
 @pytest.mark.sanity
 def test_sync_channel_sanity(cluster):
 
-    num_docs_per_channel = 2
+    num_docs_per_channel = 100
     channels = ["ABC", "NBC", "CBS"]
 
     cluster.reset(config="sync_gateway_custom_sync_channel_sanity.json")

--- a/functional_tests/test_sync.py
+++ b/functional_tests/test_sync.py
@@ -75,3 +75,55 @@ def test_sync_sanity_backfill(cluster):
     time.sleep(5)
 
     verify_changes(dj_0, expected_num_docs=number_of_docs_per_pusher, expected_num_revisions=0, expected_docs=kdwb_docs)
+
+
+@pytest.mark.distributed_index
+@pytest.mark.sanity
+def test_sync_require_roles(cluster):
+
+    cluster.reset(config="sync_gateway_custom_sync_require_roles.json")
+
+    radio_stations = ["KMOW", "HWOD", "KDWB"]
+    tv_stations = ["ABC", "CBS", "NBC"]
+
+    number_of_djs = 10
+    number_of_vjs = 10
+
+    number_of_docs_per_pusher = 100
+
+    admin = Admin(cluster.sync_gateways[0])
+
+    admin.create_role("db", name="radio_stations", channels=radio_stations)
+    admin.create_role("db", name="tv_stations", channels=tv_stations)
+
+    djs = admin.register_bulk_users(target=cluster.sync_gateways[0], db="db", name_prefix="dj", number=number_of_djs, password="password", roles=["radio_stations"])
+    vjs = admin.register_bulk_users(target=cluster.sync_gateways[0], db="db", name_prefix="vj", number=number_of_vjs, password="password", roles=["tv_stations"])
+
+    mogul = admin.register_user(target=cluster.sync_gateways[0], db="db", name="mogul", password="password", roles=["tv_stations", "radio_stations"])
+
+    radio_doc_ids = []
+    for radio_station in radio_stations:
+        doc_pusher = admin.register_user(target=cluster.sync_gateways[0], db="db", name="{}_doc_pusher".format(radio_station), password="password", channels=[radio_station], roles=["radio_stations"])
+        doc_pusher.add_docs(number_of_docs_per_pusher, uuid_names=True, bulk=True)
+        radio_doc_ids.extend(doc_pusher.cache.keys())
+
+    tv_doc_ids = []
+    for tv_station in tv_stations:
+        doc_pusher = admin.register_user(target=cluster.sync_gateways[0], db="db", name="{}_doc_pusher".format(tv_station), password="password", channels=[tv_station])
+        doc_pusher.add_docs(number_of_docs_per_pusher, uuid_names=True, bulk=True)
+        tv_doc_ids.extend(doc_pusher.cache.keys())
+
+    # Verify djs get docs for all the channels associated with the radio_stations role
+    expected_num_radio_docs = len(radio_stations) * number_of_docs_per_pusher
+    for dj in djs:
+        dj.verify_ids_from_changes(expected_num_radio_docs, radio_doc_ids)
+
+    # Verify vjs get docs for all the channels associated with the tv_stations role
+    expected_num_tv_docs = len(tv_stations) * number_of_docs_per_pusher
+    for vj in vjs:
+        vj.verify_ids_from_changes(expected_num_tv_docs, tv_doc_ids)
+
+    # Verify mogul gets docs for all the channels associated with the radio_stations + tv_stations roles
+    all_doc_ids = list(radio_doc_ids)
+    all_doc_ids.extend(tv_doc_ids)
+    mogul.verify_ids_from_changes(expected_num_radio_docs + expected_num_tv_docs, all_doc_ids)

--- a/lib/user.py
+++ b/lib/user.py
@@ -165,7 +165,7 @@ class User:
 
     # GET /{db}/{doc}
     # PUT /{db}/{doc}
-    def update_doc(self, doc_id, num_revision=1, retries=False):
+    def update_doc(self, doc_id, num_revision=1, content=None, retries=False):
 
         updated_docs = dict()
 
@@ -180,6 +180,9 @@ class User:
 
                 # Store number of updates on the document
                 data['updates'] = int(data['updates']) + 1
+
+                if content is not None:
+                    data['content'] = content
 
                 body = json.dumps(data)
 

--- a/lib/verify.py
+++ b/lib/verify.py
@@ -22,7 +22,106 @@ def verify_same_docs(expected_num_docs, doc_dict_one, doc_dict_two):
     print(" -> doc_dict_one == doc_dict_two expected (num_docs: {})".format(expected_num_docs))
 
 
-def verify_changes(users, expected_num_docs, expected_num_revisions, expected_docs):
+def verify_docs_removed(users, expected_num_docs, expected_docs):
+
+    # Verifies that the expected_docs have all been flagged with _removed = true
+    # Also verifies no duplication of changes results and set equality of the expected doc_ids
+    # and the ids returned from the _changes feed
+
+    errors = {
+        "unexpected_changes_length": 0,
+        "invalid_expected_docs_length": 0,
+        "duplicate_expected_ids": 0,
+        "duplicate_changes_doc_ids": 0,
+        "expected_doc_ids_differ_from_changes_doc_ids": 0,
+        "doc_not_removed": 0,
+        "invalid_rev_id": 0
+    }
+
+    if type(users) is list:
+        user_list = users
+    else:
+        # Allow a single user to be passed
+        user_list = list()
+        user_list.append(users)
+
+    if type(expected_docs) is not dict:
+        raise Exception("Make sure 'expected_docs' is a dictionary")
+
+    for user in user_list:
+
+        # get changes feed
+        changes = user.get_changes(include_docs=True)
+        results = changes["results"]
+
+        changes_results = list()
+        for result in results:
+            changes_result = dict()
+            if not result["id"].startswith("_user"):
+                changes_result["id"] = result["doc"]["_id"]
+                changes_result["rev"] = result["doc"]["_rev"]
+                changes_result["removed"] = result["doc"]["_removed"]
+                changes_results.append(changes_result)
+
+        # Check expected_num_docs matches number of changes results
+        if expected_num_docs != len(changes_results):
+            errors["unexpected_changes_length"] += 1
+
+        # Check number of expected num docs matched number of expected doc ids
+        if expected_num_docs != len(expected_docs):
+            errors["invalid_expected_docs_length"] += 1
+
+        # Get ids from expected docs
+        expected_doc_ids = expected_docs.keys()
+
+        # Assert there are no duplicates in expected doc ids
+        if len(expected_doc_ids) != len(set(expected_doc_ids)):
+            errors["duplicate_expected_ids"] += 1
+
+        # Get ids from all changes results
+        changes_doc_ids = [result["id"] for result in changes_results]
+
+        # Assert there are no duplicates in changes doc ids
+        if len(changes_doc_ids) != len(set(changes_doc_ids)):
+            errors["duplicate_changes_doc_ids"] += 1
+
+        # Assert the expected doc ids and changes doc ids are the same
+        if set(expected_doc_ids) != set(changes_doc_ids):
+            errors["expected_doc_ids_differ_from_changes_doc_ids"] += 1
+
+        num_doc_removed = 0
+        for result in changes_results:
+
+            # Check removed is set to true
+            if result["removed"] is not True:
+                errors["doc_not_removed"] += 1
+            elif result["removed"] is True:
+                num_doc_removed += 1
+
+            # Compare revision number for id
+            if expected_docs[result["id"]] != result["rev"]:
+                errors["invalid_rev_id"] += 1
+
+            # TODO - maybe try to ping doc endpoint and asser 4XX response?
+
+        print(" -> REMOVED |{0}| expected (num_docs: {1}) _changes (num_docs: {2}, num_removed: {3})".format(
+            user.name,
+            expected_num_docs,
+            len(changes_doc_ids),
+            num_doc_removed
+        ))
+
+        # Print any error that may have occured
+        error_count = 0
+        for key, val in errors.items():
+            if val != 0:
+                print("<!> VERIFY ERROR - name: {}: occurences: {}".format(key, val))
+                error_count += 1
+
+        assert error_count == 0
+
+
+def verify_changes(users, expected_num_docs, expected_num_revisions, expected_docs, ignore_rev_ids=False):
 
     # When users create or update a doc on sync_gateway, the response of the REST call
     # is stored in the users cache. 'expected_docs' is a scenario level dictionary created
@@ -90,10 +189,15 @@ def verify_changes(users, expected_num_docs, expected_num_revisions, expected_do
         if set(expected_doc_ids) != set(changes_doc_ids):
             errors["expected_doc_ids_differ_from_changes_doc_ids"] += 1
 
+        if ignore_rev_ids:
+            print("WARNING: Ignoring rev id verification!!")
+
         for result in changes_results:
-            # Compare revision number for id
-            if expected_docs[result["id"]] != result["rev"]:
-                errors["invalid_rev_id"] += 1
+
+            if not ignore_rev_ids:
+                # Compare revision number for id
+                if expected_docs[result["id"]] != result["rev"]:
+                    errors["invalid_rev_id"] += 1
 
             # IMPORTANT - This assumes that no conflicts are created via new_edits in the doc PUT
             # Assert that the revision id prefix matches the number of expected revisions
@@ -104,12 +208,13 @@ def verify_changes(users, expected_num_docs, expected_num_revisions, expected_do
             if expected_num_revisions != int(rev_id_prefix) - 1:
                 errors["unexpected_rev_id_prefix"] += 1
 
-            # Check number of expected updates matched the updates on the _changes doc
-            if expected_num_revisions != result["updates"]:
-                errors["unexpected_num_updates"] += 1
+            if not removed_docs:
+                # Check number of expected updates matched the updates on the _changes doc
+                if expected_num_revisions != result["updates"]:
+                    errors["unexpected_num_updates"] += 1
 
         # Allow printing updates even if changes feed length is 0
-        if len(changes_results) == 0:
+        if len(changes_results) == 0 or removed_docs:
             updates = 0
         else:
             updates = changes_results[0]["updates"]

--- a/lib/verify.py
+++ b/lib/verify.py
@@ -1,6 +1,10 @@
 
 from lib.user import User
 
+import logging
+import settings
+log = logging.getLogger(settings.LOGGER)
+
 
 def verify_same_docs(expected_num_docs, doc_dict_one, doc_dict_two):
 
@@ -19,7 +23,7 @@ def verify_same_docs(expected_num_docs, doc_dict_one, doc_dict_two):
     for k in ids_one:
         assert doc_dict_one[k] == doc_dict_two[k]
 
-    print(" -> doc_dict_one == doc_dict_two expected (num_docs: {})".format(expected_num_docs))
+    log.info(" -> doc_dict_one == doc_dict_two expected (num_docs: {})".format(expected_num_docs))
 
 
 def verify_docs_removed(users, expected_num_docs, expected_docs):
@@ -104,7 +108,7 @@ def verify_docs_removed(users, expected_num_docs, expected_docs):
 
             # TODO - maybe try to ping doc endpoint and asser 4XX response?
 
-        print(" -> REMOVED |{0}| expected (num_docs: {1}) _changes (num_docs: {2}, num_removed: {3})".format(
+        log.info(" -> REMOVED |{0}| expected (num_docs: {1}) _changes (num_docs: {2}, num_removed: {3})".format(
             user.name,
             expected_num_docs,
             len(changes_doc_ids),
@@ -115,7 +119,7 @@ def verify_docs_removed(users, expected_num_docs, expected_docs):
         error_count = 0
         for key, val in errors.items():
             if val != 0:
-                print("<!> VERIFY ERROR - name: {}: occurences: {}".format(key, val))
+                log.error("<!> VERIFY ERROR - name: {}: occurences: {}".format(key, val))
                 error_count += 1
 
         assert error_count == 0
@@ -147,6 +151,7 @@ def verify_changes(users, expected_num_docs, expected_num_revisions, expected_do
         user_list.append(users)
 
     if type(expected_docs) is not dict:
+        log.error("expected_docs is not a dictionary")
         raise Exception("Make sure 'expected_docs' is a dictionary")
 
     for user in user_list:
@@ -165,10 +170,12 @@ def verify_changes(users, expected_num_docs, expected_num_revisions, expected_do
 
         # Check expected_num_docs matches number of changes results
         if expected_num_docs != len(changes_results):
+            log.error("{} expected_num_docs != {} len(changes_results)".format(expected_num_docs, len(changes_results)))
             errors["unexpected_changes_length"] += 1
 
         # Check number of expected num docs matched number of expected doc ids
         if expected_num_docs != len(expected_docs):
+            log.error("{} expected_num_docs != {} len(expected_docs)".format(expected_num_docs, len(expected_docs)))
             errors["invalid_expected_docs_length"] += 1
 
         # Get ids from expected docs
@@ -176,6 +183,7 @@ def verify_changes(users, expected_num_docs, expected_num_revisions, expected_do
 
         # Assert there are no duplicates in expected doc ids
         if len(expected_doc_ids) != len(set(expected_doc_ids)):
+            log.error("Duplicates found in expected_doc_ids")
             errors["duplicate_expected_ids"] += 1
 
         # Get ids from all changes results
@@ -183,14 +191,16 @@ def verify_changes(users, expected_num_docs, expected_num_revisions, expected_do
 
         # Assert there are no duplicates in changes doc ids
         if len(changes_doc_ids) != len(set(changes_doc_ids)):
+            log.error("Duplicates found in changes doc ids")
             errors["duplicate_changes_doc_ids"] += 1
 
         # Assert the expected doc ids and changes doc ids are the same
         if set(expected_doc_ids) != set(changes_doc_ids):
+            log.error("changes feed doc ids differ from expected doc ids")
             errors["expected_doc_ids_differ_from_changes_doc_ids"] += 1
 
         if ignore_rev_ids:
-            print("WARNING: Ignoring rev id verification!!")
+            log.warning("WARNING: Ignoring rev id verification!!")
 
         for result in changes_results:
 
@@ -206,10 +216,12 @@ def verify_changes(users, expected_num_docs, expected_num_revisions, expected_do
             # rev-id prefix will be 1 when document is created
             # For any non-conflicting update, it will be incremented by one
             if expected_num_revisions != int(rev_id_prefix) - 1:
+                log.error("expected_num_revisions {} does not match stored rev_id_prefix: {}".format(expected_num_revisions, rev_id_prefix))
                 errors["unexpected_rev_id_prefix"] += 1
 
             # Check number of expected updates matched the updates on the _changes doc
             if expected_num_revisions != result["updates"]:
+                log.error("expected_num_revisions {} does not match number of updates {}".format(expected_num_revisions, result["updates"]))
                 errors["unexpected_num_updates"] += 1
 
         # Allow printing updates even if changes feed length is 0
@@ -218,7 +230,7 @@ def verify_changes(users, expected_num_docs, expected_num_revisions, expected_do
         else:
             updates = changes_results[0]["updates"]
 
-        print(" -> |{0}| expected (num_docs: {1} num_revisions: {2}) _changes (num_docs: {3} updates: {4})".format(
+        log.info(" -> |{0}| expected (num_docs: {1} num_revisions: {2}) _changes (num_docs: {3} updates: {4})".format(
             user.name,
             expected_num_docs,
             expected_num_revisions,
@@ -230,7 +242,7 @@ def verify_changes(users, expected_num_docs, expected_num_revisions, expected_do
         error_count = 0
         for key, val in errors.items():
             if val != 0:
-                print("<!> VERIFY ERROR - name: {}: occurences: {}".format(key, val))
+                log.error("<!> VERIFY ERROR - name: {}: occurences: {}".format(key, val))
                 error_count += 1
 
         assert error_count == 0

--- a/lib/verify.py
+++ b/lib/verify.py
@@ -170,12 +170,12 @@ def verify_changes(users, expected_num_docs, expected_num_revisions, expected_do
 
         # Check expected_num_docs matches number of changes results
         if expected_num_docs != len(changes_results):
-            log.error("{} expected_num_docs != {} len(changes_results)".format(expected_num_docs, len(changes_results)))
+            log.error("{0} -> {1} expected_num_docs != {2} len(changes_results)".format(user.name, expected_num_docs, len(changes_results)))
             errors["unexpected_changes_length"] += 1
 
         # Check number of expected num docs matched number of expected doc ids
         if expected_num_docs != len(expected_docs):
-            log.error("{} expected_num_docs != {} len(expected_docs)".format(expected_num_docs, len(expected_docs)))
+            log.error("{0} -> {1} expected_num_docs != {2} len(expected_docs)".format(user.name, expected_num_docs, len(expected_docs)))
             errors["invalid_expected_docs_length"] += 1
 
         # Get ids from expected docs
@@ -183,7 +183,7 @@ def verify_changes(users, expected_num_docs, expected_num_revisions, expected_do
 
         # Assert there are no duplicates in expected doc ids
         if len(expected_doc_ids) != len(set(expected_doc_ids)):
-            log.error("Duplicates found in expected_doc_ids")
+            log.error("{0} -> Duplicates found in expected_doc_ids".format(user.name))
             errors["duplicate_expected_ids"] += 1
 
         # Get ids from all changes results
@@ -191,12 +191,12 @@ def verify_changes(users, expected_num_docs, expected_num_revisions, expected_do
 
         # Assert there are no duplicates in changes doc ids
         if len(changes_doc_ids) != len(set(changes_doc_ids)):
-            log.error("Duplicates found in changes doc ids")
+            log.error("{0} -> Duplicates found in changes doc ids".format(user.name))
             errors["duplicate_changes_doc_ids"] += 1
 
         # Assert the expected doc ids and changes doc ids are the same
         if set(expected_doc_ids) != set(changes_doc_ids):
-            log.error("changes feed doc ids differ from expected doc ids")
+            log.error("{0} -> changes feed doc ids differ from expected doc ids".format(user.name))
             errors["expected_doc_ids_differ_from_changes_doc_ids"] += 1
 
         if ignore_rev_ids:
@@ -216,12 +216,12 @@ def verify_changes(users, expected_num_docs, expected_num_revisions, expected_do
             # rev-id prefix will be 1 when document is created
             # For any non-conflicting update, it will be incremented by one
             if expected_num_revisions != int(rev_id_prefix) - 1:
-                log.error("expected_num_revisions {} does not match stored rev_id_prefix: {}".format(expected_num_revisions, rev_id_prefix))
+                log.error("{0} -> expected_num_revisions {1} does not match stored rev_id_prefix: {2}".format(user.name, expected_num_revisions, rev_id_prefix))
                 errors["unexpected_rev_id_prefix"] += 1
 
             # Check number of expected updates matched the updates on the _changes doc
             if expected_num_revisions != result["updates"]:
-                log.error("expected_num_revisions {} does not match number of updates {}".format(expected_num_revisions, result["updates"]))
+                log.error("{0} -> expected_num_revisions {1} does not match number of updates {2}".format(user.name, expected_num_revisions, result["updates"]))
                 errors["unexpected_num_updates"] += 1
 
         # Allow printing updates even if changes feed length is 0

--- a/lib/verify.py
+++ b/lib/verify.py
@@ -208,13 +208,12 @@ def verify_changes(users, expected_num_docs, expected_num_revisions, expected_do
             if expected_num_revisions != int(rev_id_prefix) - 1:
                 errors["unexpected_rev_id_prefix"] += 1
 
-            if not removed_docs:
-                # Check number of expected updates matched the updates on the _changes doc
-                if expected_num_revisions != result["updates"]:
-                    errors["unexpected_num_updates"] += 1
+            # Check number of expected updates matched the updates on the _changes doc
+            if expected_num_revisions != result["updates"]:
+                errors["unexpected_num_updates"] += 1
 
         # Allow printing updates even if changes feed length is 0
-        if len(changes_results) == 0 or removed_docs:
+        if len(changes_results) == 0:
             updates = 0
         else:
             updates = changes_results[0]["updates"]


### PR DESCRIPTION
- Add sanity test for access() in sync function
- Add sanity test for channel() in sync function
- Add sanity test for role() in sync function
- Add requireRoles() sanity test
- Add ignore_rev_ids=False to verify changes. This is to ignore rev_id checking for the situation where the user verify their changes includes doc that they did not create or update
- Add verify_docs_removed function (Needs REVIEW) to check a users changes feed that had documents in channels that were changed