### PR TITLE
Remove hack to point load generators at all sync gw nodes

### DIFF
--- a/performance_tests/generate_gateload_configs.py
+++ b/performance_tests/generate_gateload_configs.py
@@ -43,14 +43,9 @@ def sync_gateway_non_index_writers():
     Get all the sync gateways that are not index writers, since we 
     don't want to send load to those
     """
-    
-    # Due to https://github.com/couchbase/sync_gateway/issues/1289#issuecomment-160743751
-    # I'm temporarily just pointing load generators at ALL sync gw nodes, index writers included.
-    # sync_gateways = hosts_for_tag("sync_gateways")
-    # sync_gateway_index_writers = hosts_for_tag("sync_gateway_index_writers")
-    # return [sg for sg in sync_gateways if sg not in sync_gateway_index_writers]
-    return hosts_for_tag("sync_gateways")
-
+    sync_gateways = hosts_for_tag("sync_gateways")
+    sync_gateway_index_writers = hosts_for_tag("sync_gateway_index_writers")
+    return [sg for sg in sync_gateways if sg not in sync_gateway_index_writers]
 
 def render_gateload_template(sync_gateway, user_offset, number_of_pullers, number_of_pushers):
         # run template to produce file


### PR DESCRIPTION
Since https://github.com/couchbase/sync_gateway/issues/1289#issuecomment-160743751 is now resolved, I reverted this change so that it meets the original spec where the load generators are pointed at the non index-writers.