### PR TITLE
Add missing REST endpoints for db online / offline tests

### DIFF
--- a/functional_tests/test_db_online_offline.py
+++ b/functional_tests/test_db_online_offline.py
@@ -18,7 +18,7 @@ from multiprocessing.pool import ThreadPool
 import logging
 log = logging.getLogger(lib.settings.LOGGER)
 
-NUM_ENDPOINTS = 10
+NUM_ENDPOINTS = 12
 
 def rest_scan(sync_gateway, db, online, num_docs, user_name, channels):
 
@@ -141,6 +141,21 @@ def rest_scan(sync_gateway, db, online, num_docs, user_name, channels):
         except HTTPError as e:
             log.error((e.response.url, e.response.status_code))
             error_responses.append((e.response.url, e.response.status_code))
+
+    # PUT /{db}/{local-doc-id}
+    try:
+        doc = user.add_doc("_local/a-local-doc", content={"message": "I should not be replicated"})
+    except HTTPError as e:
+        log.error((e.response.url, e.response.status_code))
+        error_responses.append((e.response.url, e.response.status_code))
+
+    # GET /{db}/{local-doc-id}
+    try:
+        doc = user.get_doc("_local/a-local-doc")
+        assert(doc["content"]["message"] == "I should not be replicated")
+    except HTTPError as e:
+        log.error((e.response.url, e.response.status_code))
+        error_responses.append((e.response.url, e.response.status_code))
 
     # GET /{db}/_all_docs
     try:

--- a/functional_tests/test_db_online_offline.py
+++ b/functional_tests/test_db_online_offline.py
@@ -1,6 +1,7 @@
 import pytest
 import time
 import concurrent.futures
+import uuid
 
 from lib.admin import Admin
 from lib.user import User
@@ -144,15 +145,16 @@ def rest_scan(sync_gateway, db, online, num_docs, user_name, channels):
             error_responses.append((e.response.url, e.response.status_code))
 
     # PUT /{db}/{local-doc-id}
+    local_doc_id = uuid.uuid4()
     try:
-        doc = user.add_doc("_local/a-local-doc", content={"message": "I should not be replicated"})
+        doc = user.add_doc("_local/{}".format(local_doc_id), content={"message": "I should not be replicated"})
     except HTTPError as e:
         log.error((e.response.url, e.response.status_code))
         error_responses.append((e.response.url, e.response.status_code))
 
     # GET /{db}/{local-doc-id}
     try:
-        doc = user.get_doc("_local/a-local-doc")
+        doc = user.get_doc("_local/{}".format(local_doc_id))
         assert(doc["content"]["message"] == "I should not be replicated")
     except HTTPError as e:
         log.error((e.response.url, e.response.status_code))

--- a/lib/verify.py
+++ b/lib/verify.py
@@ -195,6 +195,8 @@ def verify_changes(users, expected_num_docs, expected_num_revisions, expected_do
         # Assert the expected doc ids and changes doc ids are the same
         if set(expected_doc_ids) != set(changes_doc_ids):
             log.error("{0} -> changes feed doc ids differ from expected doc ids".format(user.name))
+            different_docs = set(expected_doc_ids) - set(changes_doc_ids)
+            log.error("{0} -> Set difference {1}".format(user.name, different_docs))
             errors["expected_doc_ids_differ_from_changes_doc_ids"] += 1
 
         if ignore_rev_ids:


### PR DESCRIPTION
Fixes #178 

Framework enhancements 
- Add user.get_docs(doc_ids), which used _bulk_get in the implementation
- Add user.add_doc, which uses a POST to /{db}/ and lets sync_gateway generate the doc id
- Support for local docs in add_doc("_local/{name}")
- Add user.get_doc()

Test enhancement
- Hit these endpoints in db online / offline scenarios