### PR TITLE
Fix "test_multiple_users_multiple_channels_mulitple_revisions" test

### DIFF
--- a/functional_tests/test_multiple_users_multiple_channels_multiple_revisions.py
+++ b/functional_tests/test_multiple_users_multiple_channels_multiple_revisions.py
@@ -64,8 +64,9 @@ def test_mulitple_users_mulitiple_channels_mulitple_revisions(cluster, num_users
 
     expected_docs = num_users * num_docs
     for user_obj, docs in recieved_docs.items():
-        assert docs == expected_docs
         log.info('User {} got {} docs, expected docs: {}'.format(user_obj.name, docs, expected_docs))
+        assert docs == expected_docs
+
 
     # Verify that
     # user created doc-ids exist in docs received in changes feed

--- a/lib/user.py
+++ b/lib/user.py
@@ -242,15 +242,23 @@ class User:
         return errors
 
     def get_num_docs(self):
-        if self.changes_data['results'][0]['id'].startswith("_user"):
-            return len(self.changes_data['results']) - 1
-        return len(self.changes_data['results'])
+        # add this variable to not count "_user" id in changes feed
+        adjustment = 0
+        for index in range(len(self.changes_data['results'])):
+            if self.changes_data['results'][index]['id'].startswith("_user"):
+                adjustment += 1
+                log.info("Found \"_user\" id in changes feed")
+                log.info(self.changes_data['results'][index]['id'])
+        log.info("get_num_docs = {}".format(len(self.changes_data['results']) - adjustment))
+        return len(self.changes_data['results']) - adjustment
 
     # returns a dictionary of type doc[revision]
     def get_num_revisions(self):
         docs = {}
 
         for obj in self.changes_data['results']:
+            if obj["id"].startswith("_user"):
+                continue
             revision = obj["changes"][0]["rev"]
             log.debug(revision)
             match = re.search('(\d+)-\w+', revision)


### PR DESCRIPTION
Added logic to ignore the "_user" object in changes feed and returning total sum to not include '_user'.