### PR TITLE
Automatically put bucket in offline mode when lose DCP feed #1085

### DIFF
--- a/conf/bucket_online_offline/bucket_online_offline_default_dcp_cc.json
+++ b/conf/bucket_online_offline/bucket_online_offline_default_dcp_cc.json
@@ -1,0 +1,19 @@
+{
+    "interface":":4984",
+    "adminInterface": "0.0.0.0:4985",
+    "maxIncomingConnections": 0,
+    "maxCouchbaseConnections": 16,
+    "maxFileDescriptors": 90000,
+    "slowServerCallWarningThreshold": 500,
+    "compressResponses": true,
+    "log": ["CRUD+", "Cache+", "HTTP+", "Changes+"],
+    "verbose":"true",
+    "databases":{
+        "db":{
+            "server":"http://{{ couchbase_server_primary_node }}:8091",
+            "bucket":"data-bucket",
+            "feed_type":"DCP"
+        }
+    }
+}
+

--- a/functional_tests/test_db_online_offline.py
+++ b/functional_tests/test_db_online_offline.py
@@ -515,9 +515,10 @@ def test_offline_true_config_bring_online(cluster, conf, num_docs):
 @pytest.mark.parametrize(
     "conf,num_docs",
     [
-        ("bucket_online_offline/bucket_online_offline_default.json", 100)
+        ("bucket_online_offline/bucket_online_offline_default.json", 100),
+        ("bucket_online_offline/bucket_online_offline_default_dcp_cc.json", 100)
     ],
-    ids=["CC-1"]
+    ids=["CC-1", "CC-2"]
 )
 def test_db_offline_tap_loss_sanity(cluster, conf, num_docs):
 


### PR DESCRIPTION
https://github.com/couchbase/sync_gateway/issues/1085

@sethrosetter there is a PR to merge the changes for https://github.com/couchbase/sync_gateway/issues/1085.  The expectation is that before that PR is merged, this test would fail, afterwards, it should pass.

 