### PR TITLE
Silent Failure Audit

### DIFF
--- a/functional_tests/test_continuous.py
+++ b/functional_tests/test_continuous.py
@@ -42,30 +42,26 @@ def test_continuous_changes_parametrized(cluster, conf, num_users, num_docs, num
     abc_doc_pusher = admin.register_user(target=cluster.sync_gateways[2], db="db", name="abc_doc_pusher", password="password", channels=["ABC"])
     doc_terminator = admin.register_user(target=cluster.sync_gateways[2], db="db", name="doc_terminator", password="password", channels=["TERMINATE"])
 
-    with concurrent.futures.ThreadPoolExecutor(max_workers=lib.settings.MAX_REQUEST_WORKERS) as executor:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=100) as executor:
 
         futures = {executor.submit(user.start_continuous_changes_tracking, termination_doc_id="killcontinuous"): user.name for user in users}
         futures[executor.submit(abc_doc_pusher.add_docs, num_docs)] = "doc_pusher"
 
         for future in concurrent.futures.as_completed(futures):
-            try:
-                task_name = futures[future]
+            task_name = futures[future]
 
-                # Send termination doc to seth continuous changes feed subscriber
-                if task_name == "doc_pusher":
-                    abc_doc_pusher.update_docs(num_revs_per_doc=num_revisions)
+            # Send termination doc to seth continuous changes feed subscriber
+            if task_name == "doc_pusher":
+                abc_doc_pusher.update_docs(num_revs_per_doc=num_revisions)
 
-                    time.sleep(10)
+                time.sleep(10)
 
-                    doc_terminator.add_doc("killcontinuous")
-                elif task_name.startswith("user"):
-                    # When the user has continuous _changes feed closed, return the docs and verify the user got all the channel docs
-                    docs_in_changes = future.result()
-                    # Expect number of docs + the termination doc + _user doc
-                    verify_same_docs(expected_num_docs=num_docs, doc_dict_one=docs_in_changes, doc_dict_two=abc_doc_pusher.cache)
-
-            except Exception as e:
-                print("Futures: error: {}".format(e))
+                doc_terminator.add_doc("killcontinuous")
+            elif task_name.startswith("user"):
+                # When the user has continuous _changes feed closed, return the docs and verify the user got all the channel docs
+                docs_in_changes = future.result()
+                # Expect number of docs + the termination doc + _user doc
+                verify_same_docs(expected_num_docs=num_docs, doc_dict_one=docs_in_changes, doc_dict_two=abc_doc_pusher.cache)
 
     # Expect number of docs + the termination doc
     verify_changes(abc_doc_pusher, expected_num_docs=num_docs, expected_num_revisions=num_revisions, expected_docs=abc_doc_pusher.cache)
@@ -95,25 +91,21 @@ def test_continuous_changes_sanity(cluster, conf, num_docs, num_revisions):
 
     docs_in_changes = dict()
 
-    with concurrent.futures.ThreadPoolExecutor(max_workers=lib.settings.MAX_REQUEST_WORKERS) as executor:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=100) as executor:
 
         futures = dict()
         futures[executor.submit(seth.start_continuous_changes_tracking, termination_doc_id="killcontinuous")] = "continuous"
         futures[executor.submit(abc_doc_pusher.add_docs, num_docs)] = "doc_pusher"
 
         for future in concurrent.futures.as_completed(futures):
-            try:
-                task_name = futures[future]
+            task_name = futures[future]
 
-                # Send termination doc to seth continuous changes feed subscriber
-                if task_name == "doc_pusher":
-                    abc_doc_pusher.update_docs(num_revs_per_doc=num_revisions)
-                    doc_terminator.add_doc("killcontinuous")
-                elif task_name == "continuous":
-                    docs_in_changes = future.result()
-
-            except Exception as e:
-                print("Futures: error: {}".format(e))
+            # Send termination doc to seth continuous changes feed subscriber
+            if task_name == "doc_pusher":
+                abc_doc_pusher.update_docs(num_revs_per_doc=num_revisions)
+                doc_terminator.add_doc("killcontinuous")
+            elif task_name == "continuous":
+                docs_in_changes = future.result()
 
     # Expect number of docs + the termination doc
     verify_changes(abc_doc_pusher, expected_num_docs=num_docs, expected_num_revisions=num_revisions, expected_docs=abc_doc_pusher.cache)

--- a/functional_tests/test_db_online_offline.py
+++ b/functional_tests/test_db_online_offline.py
@@ -340,7 +340,7 @@ def test_online_to_offline_changes_feed_controlled_close_continuous(cluster, con
                 docs_in_changes = future.result()
                 log.info("DOCS FROM CHANGES")
                 for k, v in docs_in_changes.items():
-                    log.info("DFC -> {}:{}".format(k, v))
+                    log.debug("DFC -> {}:{}".format(k, v))
 
     log.info("Number of docs from _changes ({})".format(len(docs_in_changes)))
     log.info("Number of docs add errors ({})".format(len(doc_add_errors)))
@@ -468,15 +468,15 @@ def test_online_to_offline_changes_feed_controlled_close_longpoll(cluster, conf,
                 try:
                     docs_in_changes = future.result()
                 except Exception as e:
-                    log.info(e)
-                    log.info("POLLING DONE EXCEPTION")
-                    log.info("AARGS: {}".format(e.args))
+                    log.warn(e)
+                    log.warn("POLLING DONE EXCEPTION")
+                    log.warn("ARGS: {}".format(e.args))
                     docs_in_changes = e.args[0]["docs"]
                     last_seq_num = e.args[0]["last_seq_num"]
-                    log.info("DOCS FROM longpoll")
+                    log.warn("DOCS FROM longpoll")
                     for k, v in docs_in_changes.items():
-                        log.info("DFC -> {}:{}".format(k, v))
-                    log.info("LAST_SEQ_NUM FROM longpoll {}".format(last_seq_num))
+                        log.debug("DFC -> {}:{}".format(k, v))
+                    log.warn("LAST_SEQ_NUM FROM longpoll {}".format(last_seq_num))
 
     log.info("Number of docs from _changes ({})".format(len(docs_in_changes)))
     log.info("last_seq_num _changes ({})".format(last_seq_num))

--- a/functional_tests/test_db_online_offline.py
+++ b/functional_tests/test_db_online_offline.py
@@ -327,24 +327,20 @@ def test_online_to_offline_changes_feed_controlled_close_continuous(cluster, con
         futures[executor.submit(admin.take_db_offline, "db")] = "db_offline_task"
 
         for future in concurrent.futures.as_completed(futures):
-            try:
-                task_name = futures[future]
+            task_name = futures[future]
 
-                if task_name == "db_offline_task":
-                    log.info("DB OFFLINE")
-                    # make sure db_offline returns 200
-                    assert(future.result() == 200)
-                elif task_name == "docs_push":
-                    log.info("DONE PUSHING DOCS")
-                    doc_add_errors = future.result()
-                elif task_name == "continuous":
-                    docs_in_changes = future.result()
-                    log.info("DOCS FROM CHANGES")
-                    for k, v in docs_in_changes.items():
-                        log.info("DFC -> {}:{}".format(k, v))
-
-            except Exception as e:
-                print("Futures: error: {}".format(e))
+            if task_name == "db_offline_task":
+                log.info("DB OFFLINE")
+                # make sure db_offline returns 200
+                assert(future.result() == 200)
+            elif task_name == "docs_push":
+                log.info("DONE PUSHING DOCS")
+                doc_add_errors = future.result()
+            elif task_name == "continuous":
+                docs_in_changes = future.result()
+                log.info("DOCS FROM CHANGES")
+                for k, v in docs_in_changes.items():
+                    log.info("DFC -> {}:{}".format(k, v))
 
     log.info("Number of docs from _changes ({})".format(len(docs_in_changes)))
     log.info("Number of docs add errors ({})".format(len(doc_add_errors)))
@@ -398,25 +394,21 @@ def test_online_to_offline_changes_feed_controlled_close_longpoll_sanity(cluster
         futures[executor.submit(admin.take_db_offline, "db")] = "db_offline_task"
 
         for future in concurrent.futures.as_completed(futures):
-            try:
-                task_name = futures[future]
+            task_name = futures[future]
 
-                if task_name == "db_offline_task":
-                    log.info("DB OFFLINE")
-                    # make sure db_offline returns 200
-                    assert(future.result() == 200)
-                if task_name == "polling":
-                    # Long poll will exit with 503, return docs in the exception
-                    log.info("POLLING DONE")
-                    try:
-                        docs_in_changes, last_seq_num = future.result()
-                    except Exception as e:
-                        log.error("Longpoll feed close error: {}".format(e))
-                        # long poll should be closed so this exception should never happen
-                        assert(0)
-
-            except Exception as e:
-                print("Futures: error: {}".format(e))
+            if task_name == "db_offline_task":
+                log.info("DB OFFLINE")
+                # make sure db_offline returns 200
+                assert(future.result() == 200)
+            if task_name == "polling":
+                # Long poll will exit with 503, return docs in the exception
+                log.info("POLLING DONE")
+                try:
+                    docs_in_changes, last_seq_num = future.result()
+                except Exception as e:
+                    log.error("Longpoll feed close error: {}".format(e))
+                    # long poll should be closed so this exception should never happen
+                    assert(0)
 
     # Account for _user doc
     # last_seq may be of the form '1' for channel cache or '1-0' for distributed index
@@ -461,34 +453,30 @@ def test_online_to_offline_changes_feed_controlled_close_longpoll(cluster, conf,
         futures[executor.submit(admin.take_db_offline, "db")] = "db_offline_task"
 
         for future in concurrent.futures.as_completed(futures):
-            try:
-                task_name = futures[future]
+            task_name = futures[future]
 
-                if task_name == "db_offline_task":
-                    log.info("DB OFFLINE")
-                    # make sure db_offline returns 200
-                    assert(future.result() == 200)
-                if task_name == "docs_push":
-                    log.info("DONE PUSHING DOCS")
-                    doc_add_errors = future.result()
-                if task_name == "polling":
-                    # Long poll will exit with 503, return docs in the exception
-                    log.info("POLLING DONE")
-                    try:
-                        docs_in_changes = future.result()
-                    except Exception as e:
-                        log.info(e)
-                        log.info("POLLING DONE EXCEPTION")
-                        log.info("AARGS: {}".format(e.args))
-                        docs_in_changes = e.args[0]["docs"]
-                        last_seq_num = e.args[0]["last_seq_num"]
-                        log.info("DOCS FROM longpoll")
-                        for k, v in docs_in_changes.items():
-                            log.info("DFC -> {}:{}".format(k, v))
-                        log.info("LAST_SEQ_NUM FROM longpoll {}".format(last_seq_num))
-
-            except Exception as e:
-                print("Futures: error: {}".format(e))
+            if task_name == "db_offline_task":
+                log.info("DB OFFLINE")
+                # make sure db_offline returns 200
+                assert(future.result() == 200)
+            if task_name == "docs_push":
+                log.info("DONE PUSHING DOCS")
+                doc_add_errors = future.result()
+            if task_name == "polling":
+                # Long poll will exit with 503, return docs in the exception
+                log.info("POLLING DONE")
+                try:
+                    docs_in_changes = future.result()
+                except Exception as e:
+                    log.info(e)
+                    log.info("POLLING DONE EXCEPTION")
+                    log.info("AARGS: {}".format(e.args))
+                    docs_in_changes = e.args[0]["docs"]
+                    last_seq_num = e.args[0]["last_seq_num"]
+                    log.info("DOCS FROM longpoll")
+                    for k, v in docs_in_changes.items():
+                        log.info("DFC -> {}:{}".format(k, v))
+                    log.info("LAST_SEQ_NUM FROM longpoll {}".format(last_seq_num))
 
     log.info("Number of docs from _changes ({})".format(len(docs_in_changes)))
     log.info("last_seq_num _changes ({})".format(last_seq_num))

--- a/functional_tests/test_dcp_reshard.py
+++ b/functional_tests/test_dcp_reshard.py
@@ -31,7 +31,7 @@ def test_dcp_reshard_sync_gateway_goes_down(cluster, conf):
     traun = admin.register_user(target=cluster.sync_gateways[1], db="db", name="traun", password="password", channels=["ABC", "NBC", "CBS"])
     seth = admin.register_user(target=cluster.sync_gateways[2], db="db", name="seth", password="password", channels=["FOX"])
 
-    print(">> Users added")
+    log.info(">> Users added")
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
 
@@ -40,19 +40,19 @@ def test_dcp_reshard_sync_gateway_goes_down(cluster, conf):
         # take down a sync_gateway
         futures[executor.submit(cluster.sync_gateways[0].stop)] = "sg_down"
 
-        print(">>> Adding Seth docs")  # FOX
+        log.info(">>> Adding Seth docs")  # FOX
         futures[executor.submit(seth.add_docs, 8000)] = "seth"
 
-        print(">>> Adding Traun docs")  # ABC, NBC, CBS
+        log.info(">>> Adding Traun docs")  # ABC, NBC, CBS
         futures[executor.submit(traun.add_docs, 2000, bulk=True)] = "traun"
 
         for future in concurrent.futures.as_completed(futures):
             tag = futures[future]
+            log.info("{} Completed:".format(tag))
             if tag == "sg_down":
                 # Assert takedown was successful
                 shutdown_status = future.result()
                 assert shutdown_status == 0
-            print("{} Completed:".format(tag))
 
     # TODO better way to do this
     time.sleep(60)
@@ -81,7 +81,7 @@ def test_dcp_reshard_sync_gateway_comes_up(cluster, conf):
     traun = admin.register_user(target=cluster.sync_gateways[1], db="db", name="traun", password="password", channels=["ABC", "NBC", "CBS"])
     seth = admin.register_user(target=cluster.sync_gateways[2], db="db", name="seth", password="password", channels=["FOX"])
 
-    print(">> Users added")
+    log.info(">> Users added")
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
 
@@ -92,18 +92,18 @@ def test_dcp_reshard_sync_gateway_comes_up(cluster, conf):
 
         time.sleep(5)
 
-        print(">>> Adding Traun docs")  # ABC, NBC, CBS
+        log.info(">>> Adding Traun docs")  # ABC, NBC, CBS
         futures[executor.submit(traun.add_docs, 6000)] = "traun"
 
-        print(">>> Adding Seth docs")  # FOX
+        log.info(">>> Adding Seth docs")  # FOX
         futures[executor.submit(seth.add_docs, 4000)] = "seth"
 
         for future in concurrent.futures.as_completed(futures):
             tag = futures[future]
+            log.info("{} Completed:".format(tag))
             if tag == "sg_up":
                 up_status = future.result()
                 assert up_status == 0
-            print("{} Completed:".format(tag))
 
     # TODO better way to do this
     time.sleep(60)

--- a/functional_tests/test_dcp_reshard.py
+++ b/functional_tests/test_dcp_reshard.py
@@ -47,15 +47,12 @@ def test_dcp_reshard_sync_gateway_goes_down(cluster, conf):
         futures[executor.submit(traun.add_docs, 2000, bulk=True)] = "traun"
 
         for future in concurrent.futures.as_completed(futures):
-            try:
-                tag = futures[future]
-                if tag == "sg_down":
-                    # Assert takedown was successful
-                    shutdown_status = future.result()
-                    assert shutdown_status == 0
-                print("{} Completed:".format(tag))
-            except Exception as e:
-                print("Exception thrown while adding docs: {}".format(e))
+            tag = futures[future]
+            if tag == "sg_down":
+                # Assert takedown was successful
+                shutdown_status = future.result()
+                assert shutdown_status == 0
+            print("{} Completed:".format(tag))
 
     # TODO better way to do this
     time.sleep(60)
@@ -102,21 +99,14 @@ def test_dcp_reshard_sync_gateway_comes_up(cluster, conf):
         futures[executor.submit(seth.add_docs, 4000)] = "seth"
 
         for future in concurrent.futures.as_completed(futures):
-            try:
-                tag = futures[future]
-                if tag == "sg_up":
-                    up_status = future.result()
-                    assert up_status == 0
-                print("{} Completed:".format(tag))
-            except Exception as e:
-                print("Exception thrown while adding docs: {}".format(e))
-            else:
-                print "Docs added!!"
+            tag = futures[future]
+            if tag == "sg_up":
+                up_status = future.result()
+                assert up_status == 0
+            print("{} Completed:".format(tag))
 
     # TODO better way to do this
     time.sleep(60)
-
-    # TODO: Verify up sync_gateway gets registered with CBGT
 
     verify_changes(traun, expected_num_docs=6000, expected_num_revisions=0, expected_docs=traun.cache)
     verify_changes(seth, expected_num_docs=4000, expected_num_revisions=0, expected_docs=seth.cache)

--- a/functional_tests/test_longpoll.py
+++ b/functional_tests/test_longpoll.py
@@ -48,21 +48,17 @@ def test_longpoll_changes_parametrized(cluster,conf, num_docs, num_revisions):
         futures[executor.submit(abc_doc_pusher.add_docs, num_docs)] = "doc_pusher"
 
         for future in concurrent.futures.as_completed(futures):
-            try:
-                task_name = futures[future]
+            task_name = futures[future]
 
-                # Send termination doc to seth long poller
-                if task_name == "doc_pusher":
-                    abc_doc_pusher.update_docs(num_revs_per_doc=num_revisions)
+            # Send termination doc to seth long poller
+            if task_name == "doc_pusher":
+                abc_doc_pusher.update_docs(num_revs_per_doc=num_revisions)
 
-                    time.sleep(5)
+                time.sleep(5)
 
-                    doc_terminator.add_doc("killpolling")
-                elif task_name == "polling":
-                    docs_in_changes, last_seq = future.result()
-
-            except Exception as e:
-                print("Futures: error: {}".format(e))
+                doc_terminator.add_doc("killpolling")
+            elif task_name == "polling":
+                docs_in_changes, last_seq = future.result()
 
     # Verify abc_docs_pusher gets the correct docs in changes feed
     verify_changes(abc_doc_pusher, expected_num_docs=num_docs, expected_num_revisions=num_revisions, expected_docs=abc_doc_pusher.cache)
@@ -102,18 +98,14 @@ def test_longpoll_changes_sanity(cluster, conf, num_docs, num_revisions):
         futures[executor.submit(abc_doc_pusher.add_docs, num_docs)] = "doc_pusher"
 
         for future in concurrent.futures.as_completed(futures):
-            try:
-                task_name = futures[future]
+            task_name = futures[future]
 
-                # Send termination doc to seth long poller
-                if task_name == "doc_pusher":
-                    abc_doc_pusher.update_docs(num_revs_per_doc=num_revisions)
-                    doc_terminator.add_doc("killpolling")
-                elif task_name == "polling":
-                    docs_in_changes, seq_num = future.result()
-
-            except Exception as e:
-                print("Futures: error: {}".format(e))
+            # Send termination doc to seth long poller
+            if task_name == "doc_pusher":
+                abc_doc_pusher.update_docs(num_revs_per_doc=num_revisions)
+                doc_terminator.add_doc("killpolling")
+            elif task_name == "polling":
+                docs_in_changes, seq_num = future.result()
 
     # Verify abc_docs_pusher gets the correct docs in changes feed
     verify_changes(abc_doc_pusher, expected_num_docs=num_docs, expected_num_revisions=num_revisions, expected_docs=abc_doc_pusher.cache)

--- a/functional_tests/test_overloaded_channel_cache.py
+++ b/functional_tests/test_overloaded_channel_cache.py
@@ -59,15 +59,11 @@ def test_overloaded_channel_cache(cluster, conf, num_docs, user_channels, filter
                 changes_requests.append(executor.submit(user.get_changes))
 
         for future in concurrent.futures.as_completed(changes_requests):
-            try:
-                changes = future.result()
-                if limit is not None:
-                    assert len(changes["results"]) == 50
-                else:
-                    assert len(changes["results"]) == 5001
-            except Exception as e:
-                errors.append(e)
-                print("Error getting _changes: {}".format(e))
+            changes = future.result()
+            if limit is not None:
+                assert len(changes["results"]) == 50
+            else:
+                assert len(changes["results"]) == 5001
 
         # changes feed should all be successful
         print(len(errors))


### PR DESCRIPTION
Remove try / excepts in futures where no exception should be throw. The existing behavior can cause tests to fail silently.