### PR TITLE
Verify sync_gateways do not crash during functional scenarios, Add a couple db online offline scenarios

### DIFF
--- a/functional_tests/test_cbgt_pindex.py
+++ b/functional_tests/test_cbgt_pindex.py
@@ -19,7 +19,10 @@ def test_pindex_distribution(cluster):
     # cluster.reset() method itself.
     
     cluster.reset(config="performance/sync_gateway_default_performance.json")
-    
+
+    # Verify all sync_gateways are running
+    errors = cluster.verify_sync_gateways_running()
+    assert(len(errors) == 0)
 
 
 

--- a/functional_tests/test_continuous.py
+++ b/functional_tests/test_continuous.py
@@ -66,6 +66,9 @@ def test_continuous_changes_parametrized(cluster, conf, num_users, num_docs, num
     # Expect number of docs + the termination doc
     verify_changes(abc_doc_pusher, expected_num_docs=num_docs, expected_num_revisions=num_revisions, expected_docs=abc_doc_pusher.cache)
 
+    # Verify all sync_gateways are running
+    errors = cluster.verify_sync_gateways_running()
+    assert(len(errors) == 0)
 
 @pytest.mark.distributed_index
 @pytest.mark.sanity
@@ -112,3 +115,7 @@ def test_continuous_changes_sanity(cluster, conf, num_docs, num_revisions):
 
     # Expect number of docs + the termination doc + _user doc
     verify_same_docs(expected_num_docs=num_docs, doc_dict_one=docs_in_changes, doc_dict_two=abc_doc_pusher.cache)
+
+    # Verify all sync_gateways are running
+    errors = cluster.verify_sync_gateways_running()
+    assert(len(errors) == 0)

--- a/functional_tests/test_db_online_offline.py
+++ b/functional_tests/test_db_online_offline.py
@@ -446,7 +446,7 @@ def test_online_to_offline_changes_feed_controlled_close_longpoll_sanity(cluster
         ("bucket_online_offline/bucket_online_offline_default_cc.json", 5000, 40),
         ("bucket_online_offline/bucket_online_offline_default_di.json", 5000, 40)
     ],
-    ids=["CC-1", "CC-2", "DI-3", "DI-4"]
+    ids=["CC-1", "DI-2"]
 )
 def test_online_to_offline_changes_feed_controlled_close_longpoll_sanity_mulitple_users(cluster, conf, num_docs, num_users):
 

--- a/functional_tests/test_db_online_offline.py
+++ b/functional_tests/test_db_online_offline.py
@@ -383,6 +383,66 @@ def test_online_to_offline_changes_feed_controlled_close_continuous(cluster, con
 @pytest.mark.sanity
 @pytest.mark.dbonlineoffline
 @pytest.mark.parametrize(
+    "conf, num_docs, num_users",
+    [
+        ("bucket_online_offline/bucket_online_offline_default_cc.json", 5000, 40),
+        ("bucket_online_offline/bucket_online_offline_default_di.json", 5000, 40)
+    ],
+    ids=["CC-1", "DI-2"]
+)
+def test_online_to_offline_continous_changes_feed_controlled_close_sanity_mulitple_users(cluster, conf, num_docs, num_users):
+
+    log.info("Using conf: {}".format(conf))
+    log.info("Using num_docs: {}".format(num_docs))
+
+    cluster.reset(conf)
+
+    admin = Admin(cluster.sync_gateways[0])
+    users = admin.register_bulk_users(target=cluster.sync_gateways[0], db="db", name_prefix="user", password="password", number=num_users, channels=["ABC"])
+
+    feed_close_results = list()
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=lib.settings.MAX_REQUEST_WORKERS) as executor:
+        # start continuous tracking with no timeout, will block until connection is closed by db going offline
+        futures = {executor.submit(user.start_continuous_changes_tracking, termination_doc_id=None): user.name for user in users}
+
+        time.sleep(5)
+        futures[executor.submit(admin.take_db_offline, "db")] = "db_offline_task"
+
+        for future in concurrent.futures.as_completed(futures):
+            task_name = futures[future]
+
+            if task_name == "db_offline_task":
+                log.info("DB OFFLINE")
+                # make sure db_offline returns 200
+                assert(future.result() == 200)
+            if task_name.startswith("user"):
+                # Long poll will exit with 503, return docs in the exception
+                log.info("POLLING DONE")
+                try:
+                    docs = future.result()
+                    feed_close_results.append(docs)
+                except Exception as e:
+                    log.error("Continious feed close error: {}".format(e))
+                    # continuous should be closed so this exception should never happen
+                    assert(0)
+
+    # Assert that the feed close results length is num_users
+    assert(len(feed_close_results) == num_users)
+
+    # No docs should be returned
+    for feed_result in feed_close_results:
+        assert(len(feed_result) == 0)
+
+    # Verify all sync_gateways are running
+    errors = cluster.verify_sync_gateways_running()
+    assert(len(errors) == 0)
+
+
+# Scenario 6 - longpoll
+@pytest.mark.sanity
+@pytest.mark.dbonlineoffline
+@pytest.mark.parametrize(
     "conf,num_docs",
     [
         ("bucket_online_offline/bucket_online_offline_default_cc.json", 5000),
@@ -448,7 +508,7 @@ def test_online_to_offline_changes_feed_controlled_close_longpoll_sanity(cluster
     ],
     ids=["CC-1", "DI-2"]
 )
-def test_online_to_offline_changes_feed_controlled_close_longpoll_sanity_mulitple_users(cluster, conf, num_docs, num_users):
+def test_online_to_offline_longpoll_changes_feed_controlled_close_sanity_mulitple_users(cluster, conf, num_docs, num_users):
 
     log.info("Using conf: {}".format(conf))
     log.info("Using num_docs: {}".format(num_docs))
@@ -500,6 +560,7 @@ def test_online_to_offline_changes_feed_controlled_close_longpoll_sanity_mulitpl
     # Verify all sync_gateways are running
     errors = cluster.verify_sync_gateways_running()
     assert(len(errors) == 0)
+
 
 # Scenario 6 - longpoll
 @pytest.mark.sanity

--- a/functional_tests/test_db_online_offline.py
+++ b/functional_tests/test_db_online_offline.py
@@ -223,6 +223,10 @@ def test_online_default_rest(cluster, conf, num_docs):
         db_info = admin.get_db_info("db")
         assert (db_info["state"] == "Online")
 
+    # Verify all sync_gateways are running
+    errors = cluster.verify_sync_gateways_running()
+    assert(len(errors) == 0)
+
 
 # Scenario 2
 @pytest.mark.sanity
@@ -253,6 +257,10 @@ def test_offline_false_config_rest(cluster, conf, num_docs):
         admin = Admin(sg)
         db_info = admin.get_db_info("db")
         assert (db_info["state"] == "Online")
+
+    # Verify all sync_gateways are running
+    errors = cluster.verify_sync_gateways_running()
+    assert(len(errors) == 0)
 
 
 # Scenario 3
@@ -290,6 +298,10 @@ def test_online_to_offline_check_503(cluster, conf, num_docs):
     for error_tuple in errors:
         print("({},{})".format(error_tuple[0], error_tuple[1]))
         assert(error_tuple[1] == 503)
+
+    # Verify all sync_gateways are running
+    errors = cluster.verify_sync_gateways_running()
+    assert(len(errors) == 0)
 
 
 # Scenario 5 - continuous
@@ -362,6 +374,10 @@ def test_online_to_offline_changes_feed_controlled_close_continuous(cluster, con
     # should equal the number of docs
     assert(num_docs_pushed + len(doc_add_errors) == num_docs)
 
+    # Verify all sync_gateways are running
+    errors = cluster.verify_sync_gateways_running()
+    assert(len(errors) == 0)
+
 
 # Scenario 6 - longpoll
 @pytest.mark.sanity
@@ -415,6 +431,10 @@ def test_online_to_offline_changes_feed_controlled_close_longpoll_sanity(cluster
     seq_num_component = last_seq_num.split("-")
     assert(1 == int(seq_num_component[0]))
     assert(len(docs_in_changes) == 0)
+
+    # Verify all sync_gateways are running
+    errors = cluster.verify_sync_gateways_running()
+    assert(len(errors) == 0)
 
 
 # Scenario 6 - longpoll
@@ -506,6 +526,10 @@ def test_online_to_offline_changes_feed_controlled_close_longpoll(cluster, conf,
     # should equal the number of docs
     assert(num_docs_pushed + len(doc_add_errors) == num_docs)
 
+    # Verify all sync_gateways are running
+    errors = cluster.verify_sync_gateways_running()
+    assert(len(errors) == 0)
+
 
 # Scenario 6
 @pytest.mark.sanity
@@ -547,6 +571,10 @@ def test_offline_true_config_bring_online(cluster, conf, num_docs):
     errors = rest_scan(cluster.sync_gateways[0], db="db", online=True, num_docs=num_docs, user_name="seth", channels=["ABC"])
     assert(len(errors) == 0)
 
+    # Verify all sync_gateways are running
+    errors = cluster.verify_sync_gateways_running()
+    assert(len(errors) == 0)
+
 
 # Scenario 14
 @pytest.mark.sanity
@@ -582,6 +610,10 @@ def test_db_offline_tap_loss_sanity(cluster, conf, num_docs):
     for error_tuple in errors:
         print("({},{})".format(error_tuple[0], error_tuple[1]))
         assert(error_tuple[1] == 503)
+
+    # Verify all sync_gateways are running
+    errors = cluster.verify_sync_gateways_running()
+    assert(len(errors) == 0)
 
 # Scenario 11
 @pytest.mark.sanity
@@ -629,6 +661,9 @@ def test_db_delayed_online(cluster, conf, num_docs):
     errors = rest_scan(cluster.sync_gateways[0], db="db", online=True, num_docs=num_docs, user_name="seth", channels=["ABC"])
     assert(len(errors) == 0)
 
+    # Verify all sync_gateways are running
+    errors = cluster.verify_sync_gateways_running()
+    assert(len(errors) == 0)
 
 
 @pytest.mark.sanity
@@ -670,6 +705,10 @@ def test_multiple_dbs_unique_buckets_lose_tap(cluster, conf, num_docs):
         for error_tuple in errors:
             print("({},{})".format(error_tuple[0], error_tuple[1]))
             assert(error_tuple[1] == 503)
+
+    # Verify all sync_gateways are running
+    errors = cluster.verify_sync_gateways_running()
+    assert(len(errors) == 0)
 
 
 # Reenable for 1.3

--- a/functional_tests/test_db_online_offline_resync.py
+++ b/functional_tests/test_db_online_offline_resync.py
@@ -101,6 +101,10 @@ def test_bucket_online_offline_resync_sanity(cluster, num_users, num_docs, num_r
 
     verify_changes(user_x, expected_num_docs=expected_docs, expected_num_revisions=num_revisions, expected_docs=user_objects[0].cache)
 
+    # Verify all sync_gateways are running
+    errors = cluster.verify_sync_gateways_running()
+    assert(len(errors) == 0)
+
     end = time.time()
     log.info("Test ended.")
     log.info("Main test duration: {}".format(end - init_completed))
@@ -259,6 +263,10 @@ def test_bucket_online_offline_resync_with_online(cluster, num_users, num_docs, 
 
     verify_changes(user_x, expected_num_docs=expected_docs, expected_num_revisions=num_revisions, expected_docs=all_docs)
 
+    # Verify all sync_gateways are running
+    errors = cluster.verify_sync_gateways_running()
+    assert(len(errors) == 0)
+
     end = time.time()
     log.info("Test ended.")
     log.info("Main test duration: {}".format(end - init_completed))
@@ -416,6 +424,10 @@ def test_bucket_online_offline_resync_with_offline(cluster, num_users, num_docs,
     all_docs = {k: v for user_cache in global_cache for k, v in user_cache.items()}
 
     verify_changes(user_x, expected_num_docs=expected_docs, expected_num_revisions=num_revisions, expected_docs=all_docs)
+
+    # Verify all sync_gateways are running
+    errors = cluster.verify_sync_gateways_running()
+    assert(len(errors) == 0)
 
     end = time.time()
     log.info("Test ended.")

--- a/functional_tests/test_db_online_offline_webhooks.py
+++ b/functional_tests/test_db_online_offline_webhooks.py
@@ -54,6 +54,10 @@ def test_webhooks(cluster, num_users,num_channels, num_docs, num_revisions):
     log.info("expected_events: {} received_events {}".format(expected_events, received_events))
     assert (expected_events == received_events)
 
+    # Verify all sync_gateways are running
+    errors = cluster.verify_sync_gateways_running()
+    assert(len(errors) == 0)
+
 # implements scenarios: 18 and 19
 @pytest.mark.sanity
 @pytest.mark.parametrize("num_users", [5])
@@ -119,6 +123,10 @@ def test_db_online_offline_webhooks_offline(cluster, num_users,num_channels, num
 
     ws.stop()
 
+    # Verify all sync_gateways are running
+    errors = cluster.verify_sync_gateways_running()
+    assert(len(errors) == 0)
+
 
 # implements scenarios: 21
 @pytest.mark.sanity
@@ -170,4 +178,8 @@ def test_db_online_offline_webhooks_offline(cluster, num_users,num_channels, num
     assert (last_event['state'] == 'offline')
 
     ws.stop()
+
+    # Verify all sync_gateways are running
+    errors = cluster.verify_sync_gateways_running()
+    assert(len(errors) == 0)
 

--- a/functional_tests/test_dcp_reshard.py
+++ b/functional_tests/test_dcp_reshard.py
@@ -60,6 +60,10 @@ def test_dcp_reshard_sync_gateway_goes_down(cluster, conf):
     verify_changes(traun, expected_num_docs=2000, expected_num_revisions=0, expected_docs=traun.cache)
     verify_changes(seth, expected_num_docs=8000, expected_num_revisions=0, expected_docs=seth.cache)
 
+    # Verify that the sg1 is down but the other sync_gateways are running
+    errors = cluster.verify_sync_gateways_running()
+    assert(len(errors) == 1 and errors[0] == "sg1")
+
 
 @pytest.mark.distributed_index
 @pytest.mark.extendedsanity
@@ -110,4 +114,8 @@ def test_dcp_reshard_sync_gateway_comes_up(cluster, conf):
 
     verify_changes(traun, expected_num_docs=6000, expected_num_revisions=0, expected_docs=traun.cache)
     verify_changes(seth, expected_num_docs=4000, expected_num_revisions=0, expected_docs=seth.cache)
+
+    # Verify all sync_gateways are running
+    errors = cluster.verify_sync_gateways_running()
+    assert(len(errors) == 0)
 

--- a/functional_tests/test_dcp_reshard.py
+++ b/functional_tests/test_dcp_reshard.py
@@ -62,7 +62,7 @@ def test_dcp_reshard_sync_gateway_goes_down(cluster, conf):
 
     # Verify that the sg1 is down but the other sync_gateways are running
     errors = cluster.verify_sync_gateways_running()
-    assert(len(errors) == 1 and errors[0] == "sg1")
+    assert(len(errors) == 1 and errors[0][0].hostname == "sg1")
 
 
 @pytest.mark.distributed_index

--- a/functional_tests/test_longpoll.py
+++ b/functional_tests/test_longpoll.py
@@ -66,6 +66,10 @@ def test_longpoll_changes_parametrized(cluster,conf, num_docs, num_revisions):
     # Verify docs from seth continous changes is the same as abc_docs_pusher's docs
     verify_same_docs(expected_num_docs=num_docs, doc_dict_one=docs_in_changes, doc_dict_two=abc_doc_pusher.cache)
 
+    # Verify all sync_gateways are running
+    errors = cluster.verify_sync_gateways_running()
+    assert(len(errors) == 0)
+
 
 @pytest.mark.distributed_index
 @pytest.mark.sanity
@@ -112,3 +116,7 @@ def test_longpoll_changes_sanity(cluster, conf, num_docs, num_revisions):
 
     # Verify docs from seth continous changes is the same as abc_docs_pusher's docs
     verify_same_docs(expected_num_docs=num_docs, doc_dict_one=docs_in_changes, doc_dict_two=abc_doc_pusher.cache)
+
+    # Verify all sync_gateways are running
+    errors = cluster.verify_sync_gateways_running()
+    assert(len(errors) == 0)

--- a/functional_tests/test_multiple_dbs.py
+++ b/functional_tests/test_multiple_dbs.py
@@ -61,6 +61,10 @@ def test_multiple_db_unique_data_bucket_unique_index_bucket(cluster, conf, num_u
     verify_changes(db_one_users, expected_num_docs=num_docs_per_user * num_db_users, expected_num_revisions=0, expected_docs=db_cache_docs)
     verify_changes(db_two_users, expected_num_docs=num_docs_per_user * num_db2_users, expected_num_revisions=0, expected_docs=db2_cache_docs)
 
+    # Verify all sync_gateways are running
+    errors = cluster.verify_sync_gateways_running()
+    assert(len(errors) == 0)
+
 # Kind of an edge case in that most users would not point multiple dbs at the same server bucket
 @pytest.mark.distributed_index
 @pytest.mark.sanity
@@ -110,3 +114,7 @@ def test_multiple_db_single_data_bucket_single_index_bucket(cluster, conf, num_u
 
     # Verify each user has all of the docs
     verify_changes(all_users, expected_num_docs=(num_users * 2) * num_docs_per_user, expected_num_revisions=0, expected_docs=cached_docs_from_all_users)
+
+    # Verify all sync_gateways are running
+    errors = cluster.verify_sync_gateways_running()
+    assert(len(errors) == 0)

--- a/functional_tests/test_multiple_users_multiple_channels_multiple_revisions.py
+++ b/functional_tests/test_multiple_users_multiple_channels_multiple_revisions.py
@@ -104,6 +104,11 @@ def test_mulitple_users_mulitiple_channels_mulitple_revisions(cluster, conf, num
     # Verify each User created docs are part of changes feed
     output = in_parallel(user_objects, 'check_doc_ids_in_changes_feed')
     assert True in output.values()
+
+    # Verify all sync_gateways are running
+    errors = cluster.verify_sync_gateways_running()
+    assert(len(errors) == 0)
+
     end = time.time()
     log.info("Test ended.")
     log.info("Main test duration: {}".format(end - init_completed))

--- a/functional_tests/test_overloaded_channel_cache.py
+++ b/functional_tests/test_overloaded_channel_cache.py
@@ -91,3 +91,7 @@ def test_overloaded_channel_cache(cluster, conf, num_docs, user_channels, filter
         else:
             # If number of view queries == 0 the key will not exist in the expvars
             assert("view_queries" not in resp_obj["syncGateway_changeCache"])
+
+    # Verify all sync_gateways are running
+    errors = cluster.verify_sync_gateways_running()
+    assert(len(errors) == 0)

--- a/functional_tests/test_roles.py
+++ b/functional_tests/test_roles.py
@@ -76,6 +76,10 @@ def test_roles_sanity(cluster, conf):
     all_docs = {k: v for cache in all_docs_caches for k, v in cache.items()}
     verify_changes(mogul, expected_num_docs=expected_num_radio_docs + expected_num_tv_docs, expected_num_revisions=0, expected_docs=all_docs)
 
+    # Verify all sync_gateways are running
+    errors = cluster.verify_sync_gateways_running()
+    assert(len(errors) == 0)
+
 # TODO - Add role mid scenario
 # TODO - Delete role mid scenario
 # TODO - Update role mid scenario

--- a/functional_tests/test_single_user_single_channel_doc_updates.py
+++ b/functional_tests/test_single_user_single_channel_doc_updates.py
@@ -58,6 +58,10 @@ def test_single_user_single_channel_doc_updates(cluster, conf, num_docs, num_rev
 
     verify_changes([single_user], expected_num_docs=num_docs, expected_num_revisions=num_revisions, expected_docs=single_user.cache)
 
+    # Verify all sync_gateways are running
+    errors = cluster.verify_sync_gateways_running()
+    assert(len(errors) == 0)
+
     end = time.time()
     print("TIME:{}s".format(end - start))
 

--- a/functional_tests/test_sync.py
+++ b/functional_tests/test_sync.py
@@ -115,6 +115,10 @@ def test_sync_channel_sanity(cluster, conf):
     # Verify that all docs have been flaged with _removed = true in changes feed for subscriber
     verify_docs_removed(subscriber, expected_num_docs=len(all_docs.items()), expected_docs=all_docs)
 
+    # Verify all sync_gateways are running
+    errors = cluster.verify_sync_gateways_running()
+    assert(len(errors) == 0)
+
     # TODO Push more docs to channel and make sure they do not show up in the users changes feed.
 
 
@@ -183,6 +187,10 @@ def test_sync_role_sanity(cluster, conf):
     # Verify seth sees no tv_stations channel docs
     verify_changes(seth, expected_num_docs=0, expected_num_revisions=0, expected_docs={})
 
+    # Verify all sync_gateways are running
+    errors = cluster.verify_sync_gateways_running()
+    assert(len(errors) == 0)
+
 
 @pytest.mark.sanity
 @pytest.mark.parametrize(
@@ -226,6 +234,10 @@ def test_sync_sanity(cluster, conf):
     # Make sure dj_0 sees KDWB docs in _changes feed
     verify_changes(dj_0, expected_num_docs=number_of_docs_per_pusher, expected_num_revisions=0, expected_docs=kdwb_docs)
 
+    # Verify all sync_gateways are running
+    errors = cluster.verify_sync_gateways_running()
+    assert(len(errors) == 0)
+
 
 @pytest.mark.sanity
 @pytest.mark.parametrize(
@@ -268,6 +280,10 @@ def test_sync_sanity_backfill(cluster, conf):
     time.sleep(5)
 
     verify_changes(dj_0, expected_num_docs=number_of_docs_per_pusher, expected_num_revisions=0, expected_docs=kdwb_docs)
+
+    # Verify all sync_gateways are running
+    errors = cluster.verify_sync_gateways_running()
+    assert(len(errors) == 0)
 
 
 @pytest.mark.sanity
@@ -360,3 +376,7 @@ def test_sync_require_roles(cluster, conf):
         assert not k.startswith("bad_doc")
 
     verify_changes(mogul, expected_num_docs=expected_num_radio_docs + expected_num_tv_docs, expected_num_revisions=0, expected_docs=all_docs)
+
+    # Verify all sync_gateways are running
+    errors = cluster.verify_sync_gateways_running()
+    assert(len(errors) == 0)

--- a/functional_tests/test_users_channels.py
+++ b/functional_tests/test_users_channels.py
@@ -68,6 +68,10 @@ def test_multiple_users_multiple_channels(cluster, conf):
     traun_expected_docs = {k: v for cache in traun_subset for k, v in cache.items()}
     verify_changes([traun], expected_num_docs=num_docs_seth + num_docs_adam + num_docs_traun, expected_num_revisions=0, expected_docs=traun_expected_docs)
 
+    # Verify all sync_gateways are running
+    errors = cluster.verify_sync_gateways_running()
+    assert(len(errors) == 0)
+
 
 @pytest.mark.distributed_index
 @pytest.mark.sanity
@@ -114,6 +118,10 @@ def test_muliple_users_single_channel(cluster, conf):
 
     verify_changes([seth, adam, traun], expected_num_docs=num_docs_seth + num_docs_adam + num_docs_traun, expected_num_revisions=0, expected_docs=all_docs)
 
+    # Verify all sync_gateways are running
+    errors = cluster.verify_sync_gateways_running()
+    assert(len(errors) == 0)
+
 
 @pytest.mark.distributed_index
 @pytest.mark.sanity
@@ -149,6 +157,10 @@ def test_single_user_multiple_channels(cluster, conf):
     time.sleep(10)
 
     verify_changes(users=[seth], expected_num_docs=5000, expected_num_revisions=0, expected_docs=seth.cache)
+
+    # Verify all sync_gateways are running
+    errors = cluster.verify_sync_gateways_running()
+    assert(len(errors) == 0)
 
     end = time.time()
     print("TIME:{}s".format(end - start))
@@ -192,6 +204,10 @@ def test_single_user_single_channel(cluster, conf):
     all_doc_caches = [seth.cache, admin_user.cache]
     all_docs = {k: v for cache in all_doc_caches for k, v in cache.items()}
     verify_changes([admin_user], expected_num_docs=num_seth_docs + num_admin_docs, expected_num_revisions=0, expected_docs=all_docs)
+
+    # Verify all sync_gateways are running
+    errors = cluster.verify_sync_gateways_running()
+    assert(len(errors) == 0)
 
 
 


### PR DESCRIPTION
- Fixes #142 
- Fixes #158 

- Each test now checks to see that all sync_gateways are still running at the end of the test scenario
- Adds 2 scenarios
    - 40 users subscribe to longpoll _changes with no timeout, db is taken offline, assert that the get a last_seq and that the feed is closed
    - 40 users subscribe to continous _changes with no timeout, db is taken offline, assert that the feed is closed