### PR TITLE
Feature/ansible 2.0 upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ The "controller" is the machine that runs ansible, which is typically:
 * Your developer workstation
 * A virtual machine / docker container
 
+NOTE: This repo now only supports ansible 2.0+
+
 The instructions below are docker specific, but if you look in `docker/controller/Dockerfile` it should give you an idea of the required dependencies if you want to make this work directly on your workstation.
 
 ### Start a Docker container for the Ansible Controller

--- a/conf/install_keys.py
+++ b/conf/install_keys.py
@@ -15,7 +15,7 @@ def install_keys(key_name, user_name):
     ips = []
     for host in hosts:
         host_vars = host.get_variables()
-        ips.append(host_vars["ansible_ssh_host"])
+        ips.append(host_vars["ansible_host"])
 
     print("Are you sure you would like to copy public key '{0}' to vms: {1}".format(
         key_name, ips

--- a/lib/cluster.py
+++ b/lib/cluster.py
@@ -5,6 +5,8 @@ import json
 import time
 
 import ansible.inventory
+from ansible.parsing.dataloader import DataLoader
+from ansible.vars import VariableManager
 
 from requests.exceptions import ConnectionError
 
@@ -51,12 +53,17 @@ class Cluster:
             log.error("File 'provisioning_config' not found at {}".format(os.getcwd()))
             sys.exit(1)
 
-        i = ansible.inventory.Inventory(host_list=hostfile)
+        variable_manager = VariableManager()
+        loader = DataLoader()
+
+        i = ansible.inventory.Inventory(loader=loader, variable_manager=variable_manager, host_list=hostfile)
+        variable_manager.set_inventory(i)
+
         group = i.get_group(tag)
         if group is None:
             return []
         hosts = group.get_hosts()
-        return [host.get_variables() for host in hosts]
+        return [host.get_vars() for host in hosts]
 
     def validate_cluster(self):
 

--- a/lib/cluster.py
+++ b/lib/cluster.py
@@ -30,14 +30,14 @@ class Cluster:
         lds_host_vars = self._hosts_for_tag("load_generators")
 
         # provide simple consumable dictionaries to functional framwork
-        cbs = [{"name": cbsv["inventory_hostname"], "ip": cbsv["ansible_ssh_host"]} for cbsv in cbs_host_vars]
+        cbs = [{"name": cbsv["inventory_hostname"], "ip": cbsv["ansible_host"]} for cbsv in cbs_host_vars]
 
         # Only collect sync_gateways that are not index_writers
         sgvs = [sgv for sgv in sgs_host_vars if "sync_gateway_index_writers" not in sgv["group_names"]]
-        sgs = [{"name": sgv["inventory_hostname"], "ip": sgv["ansible_ssh_host"]} for sgv in sgvs]
+        sgs = [{"name": sgv["inventory_hostname"], "ip": sgv["ansible_host"]} for sgv in sgvs]
 
-        sgsw = [{"name": sgwv["inventory_hostname"], "ip": sgwv["ansible_ssh_host"]} for sgwv in sgsw_host_vars]
-        lds = [{"name": ldv["inventory_hostname"], "ip": ldv["ansible_ssh_host"]} for ldv in lds_host_vars]
+        sgsw = [{"name": sgwv["inventory_hostname"], "ip": sgwv["ansible_host"]} for sgwv in sgsw_host_vars]
+        lds = [{"name": ldv["inventory_hostname"], "ip": ldv["ansible_host"]} for ldv in lds_host_vars]
 
         self.sync_gateways = [SyncGateway(sg) for sg in sgs]
         self.sg_accels = [SgAccel(sgw) for sgw in sgsw]

--- a/performance_tests/ansible/playbooks/configure-gatling.yml
+++ b/performance_tests/ansible/playbooks/configure-gatling.yml
@@ -44,4 +44,4 @@
     lineinfile: 
       dest=/home/projects/sg-gatling-load/pom.xml 
       regexp='<simulation.targetHosts>.*</simulation.targetHosts>' 
-      line='<simulation.targetHosts>{% set comma = joiner(",") %} {% for item in groups.sync_gateways -%} {{ comma() }}{{ hostvars[item].ansible_ssh_host }} {%- endfor %}</simulation.targetHosts>'
+      line='<simulation.targetHosts>{% set comma = joiner(",") %} {% for item in groups.sync_gateways -%} {{ comma() }}{{ hostvars[item].ansible_host }} {%- endfor %}</simulation.targetHosts>'

--- a/performance_tests/generate_gateload_configs.py
+++ b/performance_tests/generate_gateload_configs.py
@@ -52,7 +52,7 @@ def render_gateload_template(sync_gateway, user_offset, number_of_pullers, numbe
         gateload_config = open("files/gateload_config.json")
         template = Template(gateload_config.read())
         rendered = template.render(
-            sync_gateway_private_ip=sync_gateway['ansible_ssh_host'],
+            sync_gateway_private_ip=sync_gateway['ansible_host'],
             user_offset=user_offset,
             number_of_pullers=number_of_pullers,
             number_of_pushers=number_of_pushers

--- a/provision/ansible/playbooks/delete-sg-accel-artifacts.yml
+++ b/provision/ansible/playbooks/delete-sg-accel-artifacts.yml
@@ -1,7 +1,6 @@
 ---
 # Deploy sync gateway configs
 - hosts: sync_gateway_index_writers
-  sudo: true
   vars:
   tasks:
   - include: tasks/delete-sg-accel-artifacts.yml

--- a/provision/ansible/playbooks/delete-sg-accel-artifacts.yml
+++ b/provision/ansible/playbooks/delete-sg-accel-artifacts.yml
@@ -1,6 +1,6 @@
 ---
 # Deploy sync gateway configs
 - hosts: sync_gateway_index_writers
-  vars:
+  become: yes
   tasks:
   - include: tasks/delete-sg-accel-artifacts.yml

--- a/provision/ansible/playbooks/delete-sync-gateway-artifacts.yml
+++ b/provision/ansible/playbooks/delete-sync-gateway-artifacts.yml
@@ -1,7 +1,6 @@
 ---
 # Deploy sync gateway configs
 - hosts: sync_gateways
-  sudo: true
   vars:
   tasks:
   - include: tasks/delete-sync-gateway-artifacts.yml

--- a/provision/ansible/playbooks/delete-sync-gateway-artifacts.yml
+++ b/provision/ansible/playbooks/delete-sync-gateway-artifacts.yml
@@ -1,6 +1,6 @@
 ---
 # Deploy sync gateway configs
 - hosts: sync_gateways
-  vars:
+  become: yes
   tasks:
   - include: tasks/delete-sync-gateway-artifacts.yml

--- a/provision/ansible/playbooks/fetch-machine-stats.yml
+++ b/provision/ansible/playbooks/fetch-machine-stats.yml
@@ -1,6 +1,6 @@
 ---
 - hosts: sync_gateways
-  sudo: true
+  become: yes
   any_errors_fatal: true
   tasks:
 
@@ -9,7 +9,7 @@
     when: "'sync_gateway_index_writers' not in group_names"
 
 - hosts: sync_gateway_index_writers
-  sudo: true
+  become: yes
   any_errors_fatal: true
   tasks:
 

--- a/provision/ansible/playbooks/fetch-sync-gateway-logs.yml
+++ b/provision/ansible/playbooks/fetch-sync-gateway-logs.yml
@@ -1,6 +1,6 @@
 ---
 - hosts: sync_gateways
-  sudo: true
+  become: yes
   any_errors_fatal: true
   tasks:
 
@@ -12,7 +12,7 @@
     when: "'sync_gateway_index_writers' not in group_names"
 
 - hosts: sync_gateway_index_writers
-  sudo: true
+  become: yes
   any_errors_fatal: true
   tasks:
 

--- a/provision/ansible/playbooks/fetch-sync-gateway-profile.yml
+++ b/provision/ansible/playbooks/fetch-sync-gateway-profile.yml
@@ -2,7 +2,7 @@
 - hosts: sync_gateways
   remote_user: centos
   any_errors_fatal: true
-  sudo: true
+  become: yes
   tasks:
 
   # Fetch generated profile results
@@ -17,7 +17,7 @@
 - hosts: sync_gateway_index_writers
   remote_user: centos
   any_errors_fatal: true
-  sudo: true
+  become: yes
   tasks:
 
   # Fetch generated profile results on sg_accels

--- a/provision/ansible/playbooks/install-common-tools.yml
+++ b/provision/ansible/playbooks/install-common-tools.yml
@@ -1,6 +1,8 @@
 ---
 - hosts: sync_gateways:couchbase_servers:load_generators
   any_errors_fatal: true
+  become: yes
+
   tasks:
   - name: create centos user
     user: name=centos createhome=yes

--- a/provision/ansible/playbooks/install-common-tools.yml
+++ b/provision/ansible/playbooks/install-common-tools.yml
@@ -1,7 +1,6 @@
 ---
 - hosts: sync_gateways:couchbase_servers:load_generators
   any_errors_fatal: true
-  sudo: true
   tasks:
   - name: create centos user
     user: name=centos createhome=yes
@@ -31,7 +30,7 @@
     shell: pip install psutil
     # Remove go, can cause issues with version confusion if multple versions of go are on a machine
   - name: delete existing go installations
-    shell: rm -rf /usr/local/go/
+    file: path=/usr/local/go state=absent
     ignore_errors: yes
   - name: download golang
     get_url: url=https://storage.googleapis.com/golang/go1.5.1.linux-amd64.tar.gz dest=/tmp mode=0440

--- a/provision/ansible/playbooks/install-couchbase-server-package.yml
+++ b/provision/ansible/playbooks/install-couchbase-server-package.yml
@@ -1,6 +1,7 @@
 ---
 - hosts: couchbase_servers
   any_errors_fatal: true
+
   vars:
     couchbase_server_package_base_url:
     couchbase_server_package_name:
@@ -13,7 +14,7 @@
     couchbase_server_home_path: /opt/couchbase
 
     # Primary node
-    couchbase_server_primary_node: "{{ hostvars[groups.couchbase_servers[0]].ansible_ssh_host }}"
+    couchbase_server_primary_node: "{{ hostvars[groups.couchbase_servers[0]].ansible_host }}"
 
     # Current node
     couchbase_server_node: "{{ hostvars[inventory_hostname]['ansible_ssh_host'] }}"
@@ -24,11 +25,17 @@
     couchbase_server_bucket_ram: "{{ ((couchbase_server_cluster_ram|int)*0.5)|int }}"
 
   tasks:
-    # Delete previous artifacts
-    - name: delete downloads directory
-      file: path=/tmp state=absent
-    - name: delete user home files
-      file: path=/centos state=absent
+    # Remove users
+    - name: Remove centos user
+      user: name=centos state=absent remove=yes force=yes
+    - name: Remove sync_gateway user
+      user: name=sync_gateway state=absent remove=yes force=yes
+    - name: Remove sg_accel user
+      user: name=sg_accel state=absent remove=yes force=yes
+
+      # Create users
+    - name: Create centos user
+      user: name=centos createhome=yes
 
     - debug: msg="Couchbase server primary node {{ couchbase_server_primary_node }}"
     - debug: msg="Couchbase server node {{ couchbase_server_node }}"
@@ -37,11 +44,15 @@
     # Remove Couchbase Server
     - include: tasks/remove-couchbase-server.yml
 
+    # Create centos user
+    - name: Create centos user
+      user: name=centos createhome=yes
+
     # Download and install
     - name: Download couchbase server
-      get_url: url={{ couchbase_server_package_url }} dest=/tmp/{{ couchbase_server_package_name }}
+      get_url: url={{ couchbase_server_package_url }} dest=/home/centos/{{ couchbase_server_package_name }}
     - name: Install Couchbase Server
-      yum: name=/tmp/{{ couchbase_server_package_name }} state=present
+      yum: name=/home/centos/{{ couchbase_server_package_name }} state=present
     - name: Restart Couchbase Service
       service: name=couchbase-server state=restarted
     - name: raise max file descriptors

--- a/provision/ansible/playbooks/install-couchbase-server-package.yml
+++ b/provision/ansible/playbooks/install-couchbase-server-package.yml
@@ -1,7 +1,6 @@
 ---
 - hosts: couchbase_servers
   any_errors_fatal: true
-  sudo: true
   vars:
     couchbase_server_package_base_url:
     couchbase_server_package_name:
@@ -27,9 +26,9 @@
   tasks:
     # Delete previous artifacts
     - name: delete downloads directory
-      shell: rm -rf /tmp/*
+      file: path=/tmp state=absent
     - name: delete user home files
-      shell: rm -rf /centos/*
+      file: path=/centos state=absent
 
     - debug: msg="Couchbase server primary node {{ couchbase_server_primary_node }}"
     - debug: msg="Couchbase server node {{ couchbase_server_node }}"

--- a/provision/ansible/playbooks/install-couchbase-server-package.yml
+++ b/provision/ansible/playbooks/install-couchbase-server-package.yml
@@ -1,6 +1,7 @@
 ---
 - hosts: couchbase_servers
   any_errors_fatal: true
+  become: yes
 
   vars:
     couchbase_server_package_base_url:
@@ -17,7 +18,7 @@
     couchbase_server_primary_node: "{{ hostvars[groups.couchbase_servers[0]].ansible_host }}"
 
     # Current node
-    couchbase_server_node: "{{ hostvars[inventory_hostname]['ansible_ssh_host'] }}"
+    couchbase_server_node: "{{ hostvars[inventory_hostname]['ansible_host'] }}"
 
     couchbase_server_bucket_type: couchbase
     couchbase_server_bucket_port: 11211
@@ -25,17 +26,7 @@
     couchbase_server_bucket_ram: "{{ ((couchbase_server_cluster_ram|int)*0.5)|int }}"
 
   tasks:
-    # Remove users
-    - name: Remove centos user
-      user: name=centos state=absent remove=yes force=yes
-    - name: Remove sync_gateway user
-      user: name=sync_gateway state=absent remove=yes force=yes
-    - name: Remove sg_accel user
-      user: name=sg_accel state=absent remove=yes force=yes
-
-      # Create users
-    - name: Create centos user
-      user: name=centos createhome=yes
+    - include: tasks/clean-users.yml
 
     - debug: msg="Couchbase server primary node {{ couchbase_server_primary_node }}"
     - debug: msg="Couchbase server node {{ couchbase_server_node }}"
@@ -44,15 +35,11 @@
     # Remove Couchbase Server
     - include: tasks/remove-couchbase-server.yml
 
-    # Create centos user
-    - name: Create centos user
-      user: name=centos createhome=yes
-
     # Download and install
     - name: Download couchbase server
-      get_url: url={{ couchbase_server_package_url }} dest=/home/centos/{{ couchbase_server_package_name }}
+      get_url: url={{ couchbase_server_package_url }} dest=/tmp/{{ couchbase_server_package_name }}
     - name: Install Couchbase Server
-      yum: name=/home/centos/{{ couchbase_server_package_name }} state=present
+      yum: name=/tmp/{{ couchbase_server_package_name }} state=present
     - name: Restart Couchbase Service
       service: name=couchbase-server state=restarted
     - name: raise max file descriptors

--- a/provision/ansible/playbooks/install-couchbase-server-package.yml
+++ b/provision/ansible/playbooks/install-couchbase-server-package.yml
@@ -26,14 +26,13 @@
     couchbase_server_bucket_ram: "{{ ((couchbase_server_cluster_ram|int)*0.5)|int }}"
 
   tasks:
-    - include: tasks/clean-users.yml
-
     - debug: msg="Couchbase server primary node {{ couchbase_server_primary_node }}"
     - debug: msg="Couchbase server node {{ couchbase_server_node }}"
     - debug: msg="Downloading Couchbase server v. {{ couchbase_server_package_url }}"
 
     # Remove Couchbase Server
     - include: tasks/remove-couchbase-server.yml
+    - include: tasks/clean-users.yml
 
     # Download and install
     - name: Download couchbase server

--- a/provision/ansible/playbooks/install-sync-gateway-package.yml
+++ b/provision/ansible/playbooks/install-sync-gateway-package.yml
@@ -3,20 +3,24 @@
 - hosts: sync_gateways
 
   tasks:
-  # Delete previous artifacts
-  - name: delete downloads directory
-    file: path=/tmp state=absent
-  - name: delete user home files
-    file: path=/home/centos state=absent
-  - include: tasks/remove-sync-gateway.yml
-  - include: tasks/remove-sg-accel.yml
+  # Remove users
+  - name: Remove centos user
+    user: name=centos state=absent remove=yes force=yes
+  - name: Remove sync_gateway user
+    user: name=sync_gateway state=absent remove=yes force=yes
+  - name: Remove sg_accel user
+    user: name=sg_accel state=absent remove=yes force=yes
+
+    # Create users
+  - name: Create centos user
+    user: name=centos createhome=yes
 
 # Flush server buckets
 - hosts: couchbase_servers
   any_errors_fatal: true
   vars:
     # Primary node
-    couchbase_server_primary_node: "{{ hostvars[groups.couchbase_servers[0]].ansible_ssh_host }}"
+    couchbase_server_primary_node: "{{ hostvars[groups.couchbase_servers[0]].ansible_host }}"
 
     # Current node
     couchbase_server_node: "{{ hostvars[inventory_hostname]['ansible_ssh_host'] }}"
@@ -57,13 +61,13 @@
     couchbase_sync_gateway_package_base_url:
     couchbase_sync_gateway_package:
     couchbase_sync_gateway_package_url: "{{ couchbase_sync_gateway_package_base_url }}/{{ couchbase_sync_gateway_package }}"
-    couchbase_server_primary_node: "{{ hostvars[groups.couchbase_servers[0]].ansible_ssh_host }}"
+    couchbase_server_primary_node: "{{ hostvars[groups.couchbase_servers[0]].ansible_host }}"
 
   tasks:
   - debug: msg="Downloading sync_gateway v. {{ couchbase_sync_gateway_package_url }}"
     when: "'sync_gateway_index_writers' not in group_names"
   - name: Download sync_gateway rpm
-    get_url: url={{ couchbase_sync_gateway_package_url }} dest=/tmp/{{ couchbase_sync_gateway_package }}
+    get_url: url={{ couchbase_sync_gateway_package_url }} dest=/home/centos/{{ couchbase_sync_gateway_package }}
     when: "'sync_gateway_index_writers' not in group_names"
 
 # Download sg accel package
@@ -74,19 +78,19 @@
     couchbase_sync_gateway_package_base_url:
     couchbase_sg_accel_package:
     couchbase_sg_accel_package_url: "{{ couchbase_sync_gateway_package_base_url }}/{{ couchbase_sg_accel_package }}"
-    couchbase_server_primary_node: "{{ hostvars[groups.couchbase_servers[0]].ansible_ssh_host }}"
+    couchbase_server_primary_node: "{{ hostvars[groups.couchbase_servers[0]].ansible_host }}"
 
   tasks:
   - debug: msg="Downloading sg_accel v. {{ couchbase_sg_accel_package_url }}"
   - name: Download sg_accel rpm
-    get_url: url={{ couchbase_sg_accel_package_url }} dest=/tmp/{{ couchbase_sg_accel_package }}
+    get_url: url={{ couchbase_sg_accel_package_url }} dest=/home/centos/{{ couchbase_sg_accel_package }}
 
 # Deploy non writer sync_gateway configs
 - hosts: sync_gateways
   any_errors_fatal: true
   vars:
     sync_gateway_config_filepath:
-    couchbase_server_primary_node: "{{ hostvars[groups.couchbase_servers[0]].ansible_ssh_host }}"
+    couchbase_server_primary_node: "{{ hostvars[groups.couchbase_servers[0]].ansible_host }}"
     is_index_writer: "false"
   tasks:
   - include: tasks/deploy-sync-gateway-config.yml
@@ -96,7 +100,7 @@
 - hosts: sync_gateway_index_writers
   vars:
     sync_gateway_config_filepath:
-    couchbase_server_primary_node: "{{ hostvars[groups.couchbase_servers[0]].ansible_ssh_host }}"
+    couchbase_server_primary_node: "{{ hostvars[groups.couchbase_servers[0]].ansible_host }}"
     is_index_writer: "true"
   tasks:
   - include: tasks/deploy-sg-accel-config.yml
@@ -107,7 +111,7 @@
   tasks:
   # Install and start service
   - name: Install sync_gateway rpm
-    shell: rpm -i /tmp/{{ couchbase_sync_gateway_package }}
+    shell: rpm -i /home/centos/{{ couchbase_sync_gateway_package }}
     when: "'sync_gateway_index_writers' not in group_names"
   - name: wait until sync gateway to listen on port
     wait_for: port=4985 delay=2 timeout=120
@@ -119,7 +123,7 @@
   tasks:
   # Install and start service
   - name: Install sg_accel rpm
-    shell: rpm -i /tmp/{{ couchbase_sg_accel_package }}
+    shell: rpm -i /home/centos/{{ couchbase_sg_accel_package }}
   - name: Start the service
     service: name=sg_accel state=started
   - name: wait for sg_accel to listen on port

--- a/provision/ansible/playbooks/install-sync-gateway-package.yml
+++ b/provision/ansible/playbooks/install-sync-gateway-package.yml
@@ -4,6 +4,8 @@
   become: yes
 
   tasks:
+  - include: tasks/remove-sync-gateway.yml
+  - include: tasks/remove-sg-accel.yml
   - include: tasks/clean-users.yml
 
 # Flush server buckets

--- a/provision/ansible/playbooks/install-sync-gateway-package.yml
+++ b/provision/ansible/playbooks/install-sync-gateway-package.yml
@@ -1,19 +1,10 @@
 ---
 # Remove sync_gateway
 - hosts: sync_gateways
+  become: yes
 
   tasks:
-  # Remove users
-  - name: Remove centos user
-    user: name=centos state=absent remove=yes force=yes
-  - name: Remove sync_gateway user
-    user: name=sync_gateway state=absent remove=yes force=yes
-  - name: Remove sg_accel user
-    user: name=sg_accel state=absent remove=yes force=yes
-
-    # Create users
-  - name: Create centos user
-    user: name=centos createhome=yes
+  - include: tasks/clean-users.yml
 
 # Flush server buckets
 - hosts: couchbase_servers
@@ -23,7 +14,7 @@
     couchbase_server_primary_node: "{{ hostvars[groups.couchbase_servers[0]].ansible_host }}"
 
     # Current node
-    couchbase_server_node: "{{ hostvars[inventory_hostname]['ansible_ssh_host'] }}"
+    couchbase_server_node: "{{ hostvars[inventory_hostname]['ansible_host'] }}"
 
     couchbase_server_home_path: /opt/couchbase
     couchbase_server_admin_port: 8091
@@ -43,6 +34,7 @@
 # Create sync_gateway user
 - hosts: sync_gateways
   any_errors_fatal: true
+  become: yes
   tasks:
   - include: tasks/create-sync-gateway-user.yml
     when: "'sync_gateway_index_writers' not in group_names"
@@ -50,6 +42,7 @@
 # Create sg_accel user
 - hosts: sync_gateway_index_writers
   any_errors_fatal: true
+  become: yes
   tasks:
   - include: tasks/create-sg-accel-user.yml
 
@@ -67,7 +60,7 @@
   - debug: msg="Downloading sync_gateway v. {{ couchbase_sync_gateway_package_url }}"
     when: "'sync_gateway_index_writers' not in group_names"
   - name: Download sync_gateway rpm
-    get_url: url={{ couchbase_sync_gateway_package_url }} dest=/home/centos/{{ couchbase_sync_gateway_package }}
+    get_url: url={{ couchbase_sync_gateway_package_url }} dest=/tmp/{{ couchbase_sync_gateway_package }}
     when: "'sync_gateway_index_writers' not in group_names"
 
 # Download sg accel package
@@ -83,11 +76,12 @@
   tasks:
   - debug: msg="Downloading sg_accel v. {{ couchbase_sg_accel_package_url }}"
   - name: Download sg_accel rpm
-    get_url: url={{ couchbase_sg_accel_package_url }} dest=/home/centos/{{ couchbase_sg_accel_package }}
+    get_url: url={{ couchbase_sg_accel_package_url }} dest=/tmp/{{ couchbase_sg_accel_package }}
 
 # Deploy non writer sync_gateway configs
 - hosts: sync_gateways
   any_errors_fatal: true
+  become: yes
   vars:
     sync_gateway_config_filepath:
     couchbase_server_primary_node: "{{ hostvars[groups.couchbase_servers[0]].ansible_host }}"
@@ -98,6 +92,7 @@
 
 # Deploy sg_accel index writer configs
 - hosts: sync_gateway_index_writers
+  become: yes
   vars:
     sync_gateway_config_filepath:
     couchbase_server_primary_node: "{{ hostvars[groups.couchbase_servers[0]].ansible_host }}"
@@ -108,10 +103,11 @@
 # Install and launch sync_gateway service
 - hosts: sync_gateways
   any_errors_fatal: true
+  become: yes
   tasks:
   # Install and start service
   - name: Install sync_gateway rpm
-    shell: rpm -i /home/centos/{{ couchbase_sync_gateway_package }}
+    shell: rpm -i /tmp/{{ couchbase_sync_gateway_package }}
     when: "'sync_gateway_index_writers' not in group_names"
   - name: wait until sync gateway to listen on port
     wait_for: port=4985 delay=2 timeout=120
@@ -120,10 +116,11 @@
 # Install and launch sg_accel service
 - hosts: sync_gateway_index_writers
   any_errors_fatal: true
+  become: yes
   tasks:
   # Install and start service
   - name: Install sg_accel rpm
-    shell: rpm -i /home/centos/{{ couchbase_sg_accel_package }}
+    shell: rpm -i /tmp/{{ couchbase_sg_accel_package }}
   - name: Start the service
     service: name=sg_accel state=started
   - name: wait for sg_accel to listen on port

--- a/provision/ansible/playbooks/install-sync-gateway-package.yml
+++ b/provision/ansible/playbooks/install-sync-gateway-package.yml
@@ -1,21 +1,19 @@
 ---
 # Remove sync_gateway
 - hosts: sync_gateways
-  sudo: true
 
   tasks:
   # Delete previous artifacts
   - name: delete downloads directory
-    shell: rm -rf /tmp/*
+    file: path=/tmp state=absent
   - name: delete user home files
-    shell: rm -rf /home/centos/*
+    file: path=/home/centos state=absent
   - include: tasks/remove-sync-gateway.yml
   - include: tasks/remove-sg-accel.yml
 
 # Flush server buckets
 - hosts: couchbase_servers
   any_errors_fatal: true
-  sudo: true
   vars:
     # Primary node
     couchbase_server_primary_node: "{{ hostvars[groups.couchbase_servers[0]].ansible_ssh_host }}"
@@ -40,7 +38,6 @@
 
 # Create sync_gateway user
 - hosts: sync_gateways
-  sudo: true
   any_errors_fatal: true
   tasks:
   - include: tasks/create-sync-gateway-user.yml
@@ -48,7 +45,6 @@
 
 # Create sg_accel user
 - hosts: sync_gateway_index_writers
-  sudo: true
   any_errors_fatal: true
   tasks:
   - include: tasks/create-sg-accel-user.yml
@@ -56,7 +52,6 @@
 # Download sync_gateway package
 - hosts: sync_gateways
   any_errors_fatal: true
-  sudo: true
 
   vars:
     couchbase_sync_gateway_package_base_url:
@@ -74,7 +69,6 @@
 # Download sg accel package
 - hosts: sync_gateway_index_writers
   any_errors_fatal: true
-  sudo: true
 
   vars:
     couchbase_sync_gateway_package_base_url:
@@ -90,7 +84,6 @@
 # Deploy non writer sync_gateway configs
 - hosts: sync_gateways
   any_errors_fatal: true
-  sudo: true
   vars:
     sync_gateway_config_filepath:
     couchbase_server_primary_node: "{{ hostvars[groups.couchbase_servers[0]].ansible_ssh_host }}"
@@ -101,7 +94,6 @@
 
 # Deploy sg_accel index writer configs
 - hosts: sync_gateway_index_writers
-  sudo: true
   vars:
     sync_gateway_config_filepath:
     couchbase_server_primary_node: "{{ hostvars[groups.couchbase_servers[0]].ansible_ssh_host }}"
@@ -112,7 +104,6 @@
 # Install and launch sync_gateway service
 - hosts: sync_gateways
   any_errors_fatal: true
-  sudo: true
   tasks:
   # Install and start service
   - name: Install sync_gateway rpm
@@ -125,7 +116,6 @@
 # Install and launch sg_accel service
 - hosts: sync_gateway_index_writers
   any_errors_fatal: true
-  sudo: true
   tasks:
   # Install and start service
   - name: Install sg_accel rpm

--- a/provision/ansible/playbooks/install-sync-gateway-source.yml
+++ b/provision/ansible/playbooks/install-sync-gateway-source.yml
@@ -1,19 +1,10 @@
 ---
 # Remove sync_gateway
 - hosts: sync_gateways
+  become: yes
 
   tasks:
-  # Remove users
-  - name: Remove centos user
-    user: name=centos state=absent remove=yes force=yes
-  - name: Remove sync_gateway user
-    user: name=sync_gateway state=absent remove=yes force=yes
-  - name: Remove sg_accel user
-    user: name=sg_accel state=absent remove=yes force=yes
-
-    # Create users
-  - name: Create centos user
-    user: name=centos createhome=yes
+  - include: tasks/clean-users.yml
 
 # Flush server buckets
 - hosts: couchbase_servers
@@ -22,7 +13,7 @@
     # Primary node
     couchbase_server_primary_node: "{{ hostvars[groups.couchbase_servers[0]].ansible_host }}"
     # Current node
-    couchbase_server_node: "{{ hostvars[inventory_hostname]['ansible_ssh_host'] }}"
+    couchbase_server_node: "{{ hostvars[inventory_hostname]['ansible_host'] }}"
 
     couchbase_server_home_path: /opt/couchbase
     couchbase_server_admin_port: 8091

--- a/provision/ansible/playbooks/install-sync-gateway-source.yml
+++ b/provision/ansible/playbooks/install-sync-gateway-source.yml
@@ -1,24 +1,26 @@
 ---
 # Remove sync_gateway
 - hosts: sync_gateways
-  sudo: true
 
   tasks:
-  # Delete previous artifacts
-  - name: delete downloads directory
-    file: path=/tmp state=absent
-  - name: delete user home files
-    file: path/home/centos state=absent
-  - include: tasks/remove-sync-gateway.yml
-  - include: tasks/remove-sg-accel.yml
+  # Remove users
+  - name: Remove centos user
+    user: name=centos state=absent remove=yes force=yes
+  - name: Remove sync_gateway user
+    user: name=sync_gateway state=absent remove=yes force=yes
+  - name: Remove sg_accel user
+    user: name=sg_accel state=absent remove=yes force=yes
+
+    # Create users
+  - name: Create centos user
+    user: name=centos createhome=yes
 
 # Flush server buckets
 - hosts: couchbase_servers
   any_errors_fatal: true
-  sudo: true
   vars:
     # Primary node
-    couchbase_server_primary_node: "{{ hostvars[groups.couchbase_servers[0]].ansible_ssh_host }}"
+    couchbase_server_primary_node: "{{ hostvars[groups.couchbase_servers[0]].ansible_host }}"
     # Current node
     couchbase_server_node: "{{ hostvars[inventory_hostname]['ansible_ssh_host'] }}"
 
@@ -39,7 +41,6 @@
 
 # Create sync_gateway user
 - hosts: sync_gateways
-  sudo: true
   any_errors_fatal: true
   tasks:
   - include: tasks/create-sync-gateway-user.yml
@@ -47,7 +48,6 @@
 
 # Create sg_accel user
 - hosts: sync_gateway_index_writers
-  sudo: true
   any_errors_fatal: true
   tasks:
   - include: tasks/create-sg-accel-user.yml
@@ -55,7 +55,6 @@
 # Download source and build
 - hosts: sync_gateways
   any_errors_fatal: true
-  sudo: true
   vars:
     branch:
     build_flags:
@@ -93,11 +92,10 @@
 
 # Deploy sync gateway configs
 - hosts: sync_gateways
-  sudo: true
   any_errors_fatal: true
   vars:
     sync_gateway_config_filepath:
-    couchbase_server_primary_node: "{{ hostvars[groups.couchbase_servers[0]].ansible_ssh_host }}"
+    couchbase_server_primary_node: "{{ hostvars[groups.couchbase_servers[0]].ansible_host }}"
     is_index_writer: "false"
   tasks:
   - include: tasks/deploy-sync-gateway-config.yml
@@ -105,18 +103,16 @@
 
 # Deploy sg_accel configs
 - hosts: sync_gateway_index_writers
-  sudo: true
   any_errors_fatal: true
   vars:
     sync_gateway_config_filepath:
-    couchbase_server_primary_node: "{{ hostvars[groups.couchbase_servers[0]].ansible_ssh_host }}"
+    couchbase_server_primary_node: "{{ hostvars[groups.couchbase_servers[0]].ansible_host }}"
     is_index_writer: "true"
   tasks:
   - include: tasks/deploy-sg-accel-config.yml
 
 # Install sync_gateway service and wait for launch
 - hosts: sync_gateways
-  sudo: true
   any_errors_fatal: true
   tasks:
   - name: make service install script executable
@@ -131,7 +127,6 @@
 
 # Install sg_accel service and wait for launch
 - hosts: sync_gateway_index_writers
-  sudo: true
   any_errors_fatal: true
   tasks:
   - name: make service install script executable

--- a/provision/ansible/playbooks/install-sync-gateway-source.yml
+++ b/provision/ansible/playbooks/install-sync-gateway-source.yml
@@ -4,6 +4,8 @@
   become: yes
 
   tasks:
+  - include: tasks/remove-sync-gateway.yml
+  - include: tasks/remove-sg-accel.yml
   - include: tasks/clean-users.yml
 
 # Flush server buckets

--- a/provision/ansible/playbooks/install-sync-gateway-source.yml
+++ b/provision/ansible/playbooks/install-sync-gateway-source.yml
@@ -6,9 +6,9 @@
   tasks:
   # Delete previous artifacts
   - name: delete downloads directory
-    shell: rm -rf /tmp/*
+    file: path=/tmp state=absent
   - name: delete user home files
-    shell: rm -rf /home/centos/*
+    file: path/home/centos state=absent
   - include: tasks/remove-sync-gateway.yml
   - include: tasks/remove-sg-accel.yml
 

--- a/provision/ansible/playbooks/os-level-modifications.yml
+++ b/provision/ansible/playbooks/os-level-modifications.yml
@@ -2,7 +2,6 @@
 # https://github.com/couchbase/sync_gateway/issues/1193#issuecomment-150395613
 - hosts: sync_gateways:couchbase_servers:load_generators:load_balancers
   any_errors_fatal: true
-  sudo: true
   tasks:
   - name: disable scatter / gather for eth0 (see http://bit.ly/1R25bbE)
     shell: ethtool -K eth0 sg off

--- a/provision/ansible/playbooks/os-level-modifications.yml
+++ b/provision/ansible/playbooks/os-level-modifications.yml
@@ -2,6 +2,7 @@
 # https://github.com/couchbase/sync_gateway/issues/1193#issuecomment-150395613
 - hosts: sync_gateways:couchbase_servers:load_generators:load_balancers
   any_errors_fatal: true
+  become: yes
   tasks:
   - name: disable scatter / gather for eth0 (see http://bit.ly/1R25bbE)
     shell: ethtool -K eth0 sg off

--- a/provision/ansible/playbooks/remove-previous-installs.yml
+++ b/provision/ansible/playbooks/remove-previous-installs.yml
@@ -1,8 +1,9 @@
 ---
 - hosts: sync_gateways:couchbase_servers:load_generators
   any_errors_fatal: true
-  tasks:
+  become: yes
 
+  tasks:
   # Remove Couchbase Server
   - include: tasks/remove-couchbase-server.yml
 
@@ -12,6 +13,6 @@
   # Remove sync_gateway
   - include: tasks/remove-sg-accel.yml
 
-  # Remove package downloads
-  - name: Remove package install dir
+  # Remove tmp
+  - name: Remove downloads in /tmp dir
     shell: rm -rf /tmp/*

--- a/provision/ansible/playbooks/remove-previous-installs.yml
+++ b/provision/ansible/playbooks/remove-previous-installs.yml
@@ -1,7 +1,6 @@
 ---
 - hosts: sync_gateways:couchbase_servers:load_generators
   any_errors_fatal: true
-  sudo: true
   tasks:
 
   # Remove Couchbase Server

--- a/provision/ansible/playbooks/reset-sync-gateway.yml
+++ b/provision/ansible/playbooks/reset-sync-gateway.yml
@@ -21,7 +21,7 @@
   sudo: true
   vars:
     sync_gateway_config_filepath:
-    couchbase_server_primary_node: "{{ hostvars[groups.couchbase_servers[0]].ansible_ssh_host }}"
+    couchbase_server_primary_node: "{{ hostvars[groups.couchbase_servers[0]].ansible_host }}"
     webhook_ip: "{{ hostvars[groups.webhook_ip[0]].ansible_ssh_host }}"
     is_index_writer: "false"
   tasks:
@@ -32,8 +32,8 @@
   sudo: true
   vars:
     sync_gateway_config_filepath:
-    couchbase_server_primary_node: "{{ hostvars[groups.couchbase_servers[0]].ansible_ssh_host }}"
-    webhook_ip: "{{ hostvars[groups.webhook_ip[0]].ansible_ssh_host }}"
+    couchbase_server_primary_node: "{{ hostvars[groups.couchbase_servers[0]].ansible_host }}"
+    webhook_ip: "{{ hostvars[groups.webhook_ip[0]].ansible_host }}"
     is_index_writer: "true"
   tasks:
   - include: tasks/deploy-sync-gateway-config.yml
@@ -45,6 +45,6 @@
 
   vars:
     sync_gateway_config_filepath:
-    couchbase_server_primary_node: "{{ hostvars[groups.couchbase_servers[0]].ansible_ssh_host }}"
+    couchbase_server_primary_node: "{{ hostvars[groups.couchbase_servers[0]].ansible_host }}"
   tasks:
   - include: tasks/start-sync-gateway.yml

--- a/provision/ansible/playbooks/start-sg-accel.yml
+++ b/provision/ansible/playbooks/start-sg-accel.yml
@@ -11,8 +11,8 @@
   sudo: true
   vars:
     sync_gateway_config_filepath:
-    couchbase_server_primary_node: "{{ hostvars[groups.couchbase_servers[0]].ansible_ssh_host }}"
-    webhook_ip: "{{ hostvars[groups.webhook_ip[0]].ansible_ssh_host }}"
+    couchbase_server_primary_node: "{{ hostvars[groups.couchbase_servers[0]].ansible_host }}"
+    webhook_ip: "{{ hostvars[groups.webhook_ip[0]].ansible_host }}"
     is_index_writer: "true"
   tasks:
   - include: tasks/deploy-sg-accel-config.yml
@@ -22,6 +22,6 @@
   sudo: true
   vars:
     sync_gateway_config_filepath:
-    couchbase_server_primary_node: "{{ hostvars[groups.couchbase_servers[0]].ansible_ssh_host }}"
+    couchbase_server_primary_node: "{{ hostvars[groups.couchbase_servers[0]].ansible_host }}"
   tasks:
   - include: tasks/start-sg-accel.yml

--- a/provision/ansible/playbooks/start-sg-accel.yml
+++ b/provision/ansible/playbooks/start-sg-accel.yml
@@ -8,7 +8,7 @@
 # Deploy sync gateway configs (index writers)
 - hosts: sync_gateway_index_writers
   any_errors_fatal: true
-  sudo: true
+  become: yes
   vars:
     sync_gateway_config_filepath:
     couchbase_server_primary_node: "{{ hostvars[groups.couchbase_servers[0]].ansible_host }}"
@@ -19,7 +19,7 @@
 
 - hosts: sync_gateway_index_writers
   any_errors_fatal: true
-  sudo: true
+  become: yes
   vars:
     sync_gateway_config_filepath:
     couchbase_server_primary_node: "{{ hostvars[groups.couchbase_servers[0]].ansible_host }}"

--- a/provision/ansible/playbooks/start-sync-gateway.yml
+++ b/provision/ansible/playbooks/start-sync-gateway.yml
@@ -11,8 +11,8 @@
   sudo: true
   vars:
     sync_gateway_config_filepath:
-    couchbase_server_primary_node: "{{ hostvars[groups.couchbase_servers[0]].ansible_ssh_host }}"
-    webhook_ip: "{{ hostvars[groups.webhook_ip[0]].ansible_ssh_host }}"
+    couchbase_server_primary_node: "{{ hostvars[groups.couchbase_servers[0]].ansible_host }}"
+    webhook_ip: "{{ hostvars[groups.webhook_ip[0]].ansible_host }}"
     is_index_writer: "false"
   tasks:
   - include: tasks/deploy-sync-gateway-config.yml
@@ -24,7 +24,7 @@
 
   vars:
     sync_gateway_config_filepath:
-    couchbase_server_primary_node: "{{ hostvars[groups.couchbase_servers[0]].ansible_ssh_host }}"
+    couchbase_server_primary_node: "{{ hostvars[groups.couchbase_servers[0]].ansible_host }}"
   tasks:
   - include: tasks/start-sync-gateway.yml
     when: "'sync_gateway_index_writers' not in group_names"

--- a/provision/ansible/playbooks/start-sync-gateway.yml
+++ b/provision/ansible/playbooks/start-sync-gateway.yml
@@ -8,7 +8,7 @@
 
 # Deploy sync gateway configs
 - hosts: sync_gateways
-  sudo: true
+  become: yes
   vars:
     sync_gateway_config_filepath:
     couchbase_server_primary_node: "{{ hostvars[groups.couchbase_servers[0]].ansible_host }}"
@@ -20,7 +20,7 @@
 
 - hosts: sync_gateways
   any_errors_fatal: true
-  sudo: true
+  become: yes
 
   vars:
     sync_gateway_config_filepath:

--- a/provision/ansible/playbooks/stop-sg-accel.yml
+++ b/provision/ansible/playbooks/stop-sg-accel.yml
@@ -1,7 +1,7 @@
 ---
 - hosts: sync_gateway_index_writers
   any_errors_fatal: true
-  sudo: yes
+  become: yes
 
   tasks:
   - include: tasks/stop-sg-accel.yml

--- a/provision/ansible/playbooks/stop-sync-gateway.yml
+++ b/provision/ansible/playbooks/stop-sync-gateway.yml
@@ -1,7 +1,7 @@
 ---
 - hosts: sync_gateways
   any_errors_fatal: true
-  sudo: yes
+  become: yes
 
   tasks:
   - include: tasks/stop-sync-gateway.yml

--- a/provision/ansible/playbooks/tasks/clean-users.yml
+++ b/provision/ansible/playbooks/tasks/clean-users.yml
@@ -1,0 +1,4 @@
+- name: Remove sync_gateway user
+  user: name=sync_gateway state=absent remove=yes force=yes
+- name: Remove sg_accel user
+  user: name=sg_accel state=absent remove=yes force=yes

--- a/provision/ansible/playbooks/tasks/create-server-buckets.yml
+++ b/provision/ansible/playbooks/tasks/create-server-buckets.yml
@@ -7,7 +7,7 @@
 
 - hosts: couchbase_servers
   any_errors_fatal: true
-  sudo: true
+  become: true
   vars:
 
   # Primary node

--- a/provision/ansible/playbooks/tasks/create-server-buckets.yml
+++ b/provision/ansible/playbooks/tasks/create-server-buckets.yml
@@ -11,10 +11,10 @@
   vars:
 
   # Primary node
-    couchbase_server_primary_node: "{{ hostvars['cb1']['ansible_ssh_host'] }}"
+    couchbase_server_primary_node: "{{ hostvars['cb1']['ansible_host'] }}"
 
     # Current node
-    couchbase_server_node: "{{ hostvars[inventory_hostname]['ansible_ssh_host'] }}"
+    couchbase_server_node: "{{ hostvars[inventory_hostname]['ansible_host'] }}"
 
     couchbase_server_home_path: /opt/couchbase
     couchbase_server_admin_port: 8091

--- a/provision/ansible/playbooks/tasks/delete-sg-accel-artifacts.yml
+++ b/provision/ansible/playbooks/tasks/delete-sg-accel-artifacts.yml
@@ -1,9 +1,3 @@
 # Delete logs and .pindex files
-- name: delete sg_accel logs
-  shell: rm -f /home/sg_accel/logs/*.log
-- name: delete sg_accel pindex files
-  shell: rm -rf /home/sg_accel/*.pindex
-- name: delete sg_accel uuid files
-  shell: rm -rf /home/sg_accel/*.uuid
-- name: delete sg_accel configs / cpu stats
-  shell: rm -rf /home/sg_accel/*.json
+- name: delete sg_accel artifacts
+  file: path/home/sg_accel state=absent

--- a/provision/ansible/playbooks/tasks/delete-sg-accel-artifacts.yml
+++ b/provision/ansible/playbooks/tasks/delete-sg-accel-artifacts.yml
@@ -1,3 +1,3 @@
 # Delete logs and .pindex files
 - name: delete sg_accel artifacts
-  file: path/home/sg_accel state=absent
+  shell: rm -rf /home/sg_accel/*

--- a/provision/ansible/playbooks/tasks/delete-sync-gateway-artifacts.yml
+++ b/provision/ansible/playbooks/tasks/delete-sync-gateway-artifacts.yml
@@ -1,9 +1,3 @@
 # Delete logs and .pindex files
 - name: delete sync_gateway logs
-  shell: rm -f /home/sync_gateway/logs/*.log
-- name: delete sync_gateway pindex files
-  shell: rm -rf /home/sync_gateway/*.pindex
-- name: delete sync_gateway uuid files
-  shell: rm -rf /home/sync_gateway/*.uuid
-- name: delete sync_gateway configs / cpu stats
-  shell: rm -rf /home/sync_gateway/*.json
+  file: path=/home/sync_gateway state=absent

--- a/provision/ansible/playbooks/tasks/delete-sync-gateway-artifacts.yml
+++ b/provision/ansible/playbooks/tasks/delete-sync-gateway-artifacts.yml
@@ -1,3 +1,3 @@
 # Delete logs and .pindex files
 - name: delete sync_gateway logs
-  file: path=/home/sync_gateway state=absent
+  shell: rm -rf /home/sync_gateway/*

--- a/provision/ansible/playbooks/tasks/remove-couchbase-server.yml
+++ b/provision/ansible/playbooks/tasks/remove-couchbase-server.yml
@@ -5,4 +5,4 @@
   shell: rpm -e couchbase-server
   ignore_errors: yes
 - name: Remove all couchbase server residue
-  shell: rm -rf /opt/couchbase
+  file: path=/opt/couchbase state=absent

--- a/provision/ansible/playbooks/tasks/remove-sg-accel.yml
+++ b/provision/ansible/playbooks/tasks/remove-sg-accel.yml
@@ -19,24 +19,9 @@
 
 # Remove sg_accel service
 - name: Remove sg_accel service
-  shell: rm /usr/lib/systemd/system/sg_accel.service
+  file: path=/usr/lib/systemd/system/sg_accel.service state=absent
   ignore_errors: yes
 
 # Delete sg_accel binary
 - name: delete sync_gateway binary
-  shell: rm -rf /opt/couchbase-sg-accel
-
-# Delete logs and .pindex files
-- name: delete sg_accel logs
-  shell: rm -f /home/sg_accel/logs/*.log
-- name: delete sg_accel pindex files
-  shell: rm -rf /home/sg_accel/*.pindex
-
-# Remove sync_gateway user
-- name: remove sg accel user
-  user: name=sg_accel state=absent remove=yes force=yes
-  ignore_errors: yes
-
-# Delete downloaded source
-- name: delete previous sync gateway
-  command: rm -rf /home/centos/sync_gateway
+  file: path=/opt/couchbase-sg-accel state=absent

--- a/provision/ansible/playbooks/tasks/remove-sync-gateway.yml
+++ b/provision/ansible/playbooks/tasks/remove-sync-gateway.yml
@@ -20,18 +20,16 @@
 
 # Remove sync_gateway service
 - name: Remove sync_gateway service
-  shell: rm /usr/lib/systemd/system/sync_gateway.service
+  file: path=/usr/lib/systemd/system/sync_gateway.service state=absent
   ignore_errors: yes
 
 # Delete sync_gateway binary
 - name: delete sync_gateway binary
-  shell: rm -rf /opt/couchbase-sync-gateway
+  file: path=/opt/couchbase-sync-gateway state=absent
 
 # Delete logs and .pindex files
 - name: delete sync_gateway logs
-  shell: rm -f /home/sync_gateway/logs/*.log
-- name: delete sync_gateway pindex files
-  shell: rm -rf /home/sync_gateway/*.pindex
+  file: path=/home/sync_gateway state=absent
 
 # Remove sync_gateway user
 - name: remove sync gateway user
@@ -40,4 +38,4 @@
 
 # Delete downloaded source
 - name: delete previous sync gateway
-  command: rm -rf /home/centos/sync_gateway
+  file: path=/home/centos/sync_gateway state=absent

--- a/provision/ansible/playbooks/tasks/remove-sync-gateway.yml
+++ b/provision/ansible/playbooks/tasks/remove-sync-gateway.yml
@@ -26,16 +26,3 @@
 # Delete sync_gateway binary
 - name: delete sync_gateway binary
   file: path=/opt/couchbase-sync-gateway state=absent
-
-# Delete logs and .pindex files
-- name: delete sync_gateway logs
-  file: path=/home/sync_gateway state=absent
-
-# Remove sync_gateway user
-- name: remove sync gateway user
-  user: name=sync_gateway state=absent remove=yes force=yes
-  ignore_errors: yes
-
-# Delete downloaded source
-- name: delete previous sync gateway
-  file: path=/home/centos/sync_gateway state=absent

--- a/provision/generate_ansible_inventory_from_aws.py
+++ b/provision/generate_ansible_inventory_from_aws.py
@@ -9,13 +9,13 @@ import json
 Generate a provisioning_config file like:
 
 [couchbase_servers]
-cb1 ansible_ssh_host=ec2-54-147-234-108.compute-1.amazonaws.com
+cb1 ansible_host=ec2-54-147-234-108.compute-1.amazonaws.com
 
 [sync_gateways]
-sg1 ansible_ssh_host=ec2-50-16-26-70.compute-1.amazonaws.com
+sg1 ansible_host=ec2-50-16-26-70.compute-1.amazonaws.com
 
 [load_generators]
-lg1 ansible_ssh_host=ec2-54-157-59-199.compute-1.amazonaws.com
+lg1 ansible_host=ec2-54-157-59-199.compute-1.amazonaws.com
 
 """
 

--- a/provision/generate_ansible_inventory_from_aws.py
+++ b/provision/generate_ansible_inventory_from_aws.py
@@ -78,7 +78,7 @@ def get_ansible_groups():
             # create an ansible host object
             host = ansible.inventory.host.Host(ansible_inventory_name)
             host.add_group(ansible_group)
-            host.set_variable("ansible_ssh_host", hostname)
+            host.set_variable("ansible_host", hostname)
             ansible_group.add_host(host)
             i += 1
 
@@ -98,7 +98,7 @@ def add_sync_gateway_index_writers(input_ansible_groups):
             for host in ansible_group.get_hosts():
                 host_copy = ansible.inventory.host.Host(host.name)
                 host_copy.add_group(sg_writer_group)
-                host_copy.set_variable("ansible_ssh_host", host.get_variables()["ansible_ssh_host"])
+                host_copy.set_variable("ansible_host", host.get_vars()["ansible_host"])
                 sg_writer_group.add_host(host_copy)
             output_ansible_groups.append(sg_writer_group)
     return output_ansible_groups
@@ -111,11 +111,11 @@ def write_to_file(ansible_groups, filename):
         target.write(group_header)
         target.write("\n")
         for ansible_host in ansible_group.get_hosts():
-            host_variables = ansible_host.get_variables()
+            host_variables = ansible_host.get_vars()
             target.write(ansible_host.name)
             target.write(" ")
-            ansible_ssh_host = host_variables["ansible_ssh_host"]
-            line = "ansible_ssh_host={}".format(ansible_ssh_host)
+            ansible_host = host_variables["ansible_host"]
+            line = "ansible_host={}".format(ansible_host)
             target.write(line)
             target.write("\n")
 

--- a/provision/install_sync_gateway.py
+++ b/provision/install_sync_gateway.py
@@ -28,7 +28,8 @@ class SyncGatewayConfig:
         self._valid_versions = [
             "1.1.0",
             "1.1.1",
-            "1.2.0"
+            "1.2.0",
+            "1.3.0"
         ]
 
     @property

--- a/provisioning_config.example
+++ b/provisioning_config.example
@@ -1,17 +1,17 @@
 [couchbase_servers]
-cb1 ansible_ssh_host=172.23.105.164
-cb2 ansible_ssh_host=172.23.105.165
+cb1 ansible_host=172.23.105.164
+cb2 ansible_host=172.23.105.165
 
 [sync_gateways]
-sg1 ansible_ssh_host=172.23.122.250
-sg2 ansible_ssh_host=172.23.122.251
-sg3 ansible_ssh_host=172.23.122.252
-sg4 ansible_ssh_host=172.23.122.253
+sg1 ansible_host=172.23.122.250
+sg2 ansible_host=172.23.122.251
+sg3 ansible_host=172.23.122.252
+sg4 ansible_host=172.23.122.253
 
 [load_generators]
 
 [sync_gateway_index_writers]
-sg1 ansible_ssh_host=172.23.122.250
-sg2 ansible_ssh_host=172.23.122.251
-sg3 ansible_ssh_host=172.23.122.252
-sg4 ansible_ssh_host=172.23.122.253
+sg1 ansible_host=172.23.122.250
+sg2 ansible_host=172.23.122.251
+sg3 ansible_host=172.23.122.252
+sg4 ansible_host=172.23.122.253

--- a/utilities/analyze_perf_results.py
+++ b/utilities/analyze_perf_results.py
@@ -110,7 +110,7 @@ def plot_sync_gateway_expvars(figure, json_file_name):
 
     # Get writer hostnames for provisioning_config
     sg_writers = hosts_for_tag("sync_gateway_index_writers")
-    sg_writer_hostnames = [sg_writer["ansible_ssh_host"] for sg_writer in sg_writers]
+    sg_writer_hostnames = [sg_writer["ansible_host"] for sg_writer in sg_writers]
 
     with open(json_file_name, "r") as f:
         obj = json.loads(f.read(), object_pairs_hook=OrderedDict)

--- a/utilities/log_expvars.py
+++ b/utilities/log_expvars.py
@@ -38,14 +38,14 @@ def log_expvars(folder_name):
 
     # Get gateload ips from ansible inventory
     lgs_host_vars = hosts_for_tag("load_generators")
-    lgs = [lg["ansible_ssh_host"] for lg in lgs_host_vars]
+    lgs = [lg["ansible_host"] for lg in lgs_host_vars]
 
     print("Monitoring gateloads: {}".format(lgs))
     lgs_expvar_endpoints = [lg + ":9876/debug/vars" for lg in lgs]
 
     # Get sync_gateway ips from ansible inventory
     sgs_host_vars = hosts_for_tag("sync_gateways")
-    sgs = [sgv["ansible_ssh_host"] for sgv in sgs_host_vars]
+    sgs = [sgv["ansible_host"] for sgv in sgs_host_vars]
 
     print("Monitoring sync_gateways: {}".format(sgs))
     sgs_expvar_endpoints = [sg + ":4985/_expvar" for sg in sgs]

--- a/utilities/monitor_gateload.py
+++ b/utilities/monitor_gateload.py
@@ -10,7 +10,7 @@ if __name__ == "__main__":
 
     # Get gateload ips from ansible inventory
     lgs_host_vars = hosts_for_tag("load_generators")
-    lgs = [lg["ansible_ssh_host"] for lg in lgs_host_vars]
+    lgs = [lg["ansible_host"] for lg in lgs_host_vars]
 
     if len(lgs) == 0:
         print("No gateloads to monitor in 'provisioning_config'")

--- a/utilities/monitor_sync_gateway.py
+++ b/utilities/monitor_sync_gateway.py
@@ -11,7 +11,7 @@ if __name__ == "__main__":
 
     # Get sync_gateway ips from ansible inventory
     sgs_host_vars = hosts_for_tag("sync_gateways")
-    sgs = [sgv["ansible_ssh_host"] for sgv in sgs_host_vars]
+    sgs = [sgv["ansible_host"] for sgv in sgs_host_vars]
 
     if len(sgs) == 0:
         print("No sync_gateways to monitor in 'provisioning_config'")


### PR DESCRIPTION
! IMPORTANT - After merge, the provisioning is not guaranteed to work with pre 2.0 ansible so make sure you do the following
```
pip uninstall ansible
pip install ansible
```

Also, @adamcfraser and @tleyden, heads up ^

Provisioning now supports ansible 2.0
- changed sudo: True -> become: yes (sudo is being deprecated)
- ansible_ssh_host -> ansible_host
- minor provisioning clean up 
    - used file module to remove in as many places as I could
- minor API changes when using Ansible python API